### PR TITLE
Fix: Pass relationships params in url

### DIFF
--- a/lib/hunter/api/http_client.ex
+++ b/lib/hunter/api/http_client.ex
@@ -102,9 +102,11 @@ defmodule Hunter.Api.HTTPClient do
   end
 
   def relationships(conn, ids) do
-    "/api/v1/accounts/relationships"
+    ids_array = Enum.map(ids, fn id -> "id[]=#{id}&" end)
+
+    "/api/v1/accounts/relationships?#{ids_array}"
     |> process_url(conn)
-    |> request!(:relationships, :get, %{id: ids}, conn)
+    |> request!(:relationships, :get, [], conn)
   end
 
   def follow(conn, id) do


### PR DESCRIPTION
Arrays of id should be passed in request url, not in body:
https://docs.toot.app/en/api/rest/accounts/#get-api-v1-accounts-relationships