### PR TITLE
Change default base_url to nil

### DIFF
--- a/lib/hunter/client.ex
+++ b/lib/hunter/client.ex
@@ -63,7 +63,7 @@ defmodule Hunter.Client do
 
   """
   @spec log_in_oauth(Hunter.Application.t(), String.t(), String.t()) :: Hunter.Client.t()
-  def log_in_oauth(app, oauth_code, base_url \\ "https://mastodon.social") do
+  def log_in_oauth(app, oauth_code, base_url \\ nil) do
     base_url = base_url || Config.api_base_url()
     Config.hunter_api().log_in_oauth(app, oauth_code, base_url)
   end


### PR DESCRIPTION
Change the default argument for base_rule in login/3 to nil in order to properly make use of the short circuit logic in the function.

As it is now someone calling this function has  to explicitly supply nil if they have already configured their base_url elsewhere (e.g. mix.exs).