### PR TITLE
API-drift cleanup: v2 search shape, drop removed endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@
   * Breaking changes
     - Require Elixir 1.15+ and Erlang/OTP 26+ (transitive dependencies of
       httpoison 3.0 no longer compile on OTP 25)
+    - `Hunter.Result.hashtags` is now a list of `Hunter.Tag` structs (the
+      `/api/v2/search` shape) instead of strings.
+    - Removed `Hunter.follow_by_uri/2` / `Hunter.Account.follow_by_uri/2`:
+      Mastodon 4.0 removed `POST /api/v1/follows`. Search for the account and
+      use `Hunter.follow/2` instead.
+    - Removed `Hunter.reports/1` / `Hunter.Report.reports/1`: Mastodon removed
+      `GET /api/v1/reports`. Filing reports via `Hunter.report/4` still works.
 
 ## v0.5.1
 

--- a/README.md
+++ b/README.md
@@ -155,23 +155,6 @@ iex> Hunter.following(conn, 8039)
 
  Returns a list of `Hunter.Account`
 
-### Following a remote user
-
-```elixir
-iex> Hunter.follow_by_uri(conn, "paperswelove@mstdn.io")
-%Hunter.Account{acct: "paperswelove@mstdn.io",
- avatar: "https://social.lou.lt/system/accounts/avatars/000/007/126/original/60ecc8225809c008.png?1491486258",
- created_at: "2017-04-06T13:44:18.281Z", display_name: "Papers We Love",
- followers_count: 1, following_count: 0,
- header: "https://social.lou.lt/system/accounts/headers/000/007/126/original/missing.png?1491486258",
- id: 7126, locked: false,
- note: "Building Bridges Between Academia and Industry\r\n\r\n<a href=\"http://paperswelove.org\" rel=\"nofollow noopener\"><span class=\"invisible\">http://</span><span class=\"\">paperswelove.org</span><span class=\"invisible\"></span></a>\r\n<a href=\"http://pwlconf.org\" rel=\"nofollow noopener noopener\"><span class=\"invisible\">http://</span><span class=\"\">pwlconf.org</span><span class=\"invisible\"></span></a>",
- statuses_count: 1, url: "https://mstdn.io/@paperswelove",
- username: "paperswelove"}
- ```
-
- Returns a `Hunter.Account`
-
 ### Muting/unmuting an account
 
 ```elixir
@@ -364,15 +347,6 @@ iex> Hunter.mutes(conn)
 ```
 
 Returns a list of `Hunter.Account` muted by the authenticated user.
-
-### Fetch user's reports
-
-```elixir
-iex> Hunter.reports(conn)
-[]
-```
-
-Returns a list of `Hunter.Report` made by the authenticated user.
 
 ### Filter statuses given a hashtag
 

--- a/lib/hunter.ex
+++ b/lib/hunter.ex
@@ -86,18 +86,6 @@ defmodule Hunter do
   defdelegate following(conn, id, options \\ []), to: Hunter.Account
 
   @doc """
-  Follow a remote user
-
-  ## Parameters
-
-    * `conn` - connection credentials
-    * `uri` - URI of the remote user, in the format of `username@domain`
-
-  """
-  @spec follow_by_uri(Hunter.Client.t(), String.t()) :: Hunter.Account.t()
-  defdelegate follow_by_uri(conn, uri), to: Hunter.Account
-
-  @doc """
   Search for accounts
 
   ## Parameters
@@ -669,17 +657,6 @@ defmodule Hunter do
   """
   @spec clear_notification(Hunter.Client.t(), non_neg_integer) :: boolean
   defdelegate clear_notification(conn, id), to: Hunter.Notification
-
-  @doc """
-  Retrieve a user's reports
-
-  ## Parameters
-
-    * `conn` - connection credentials
-
-  """
-  @spec reports(Hunter.Client.t()) :: [Hunter.Report.t()]
-  defdelegate reports(conn), to: Hunter.Report
 
   @doc """
   Report a user

--- a/lib/hunter/account.ex
+++ b/lib/hunter/account.ex
@@ -191,20 +191,6 @@ defmodule Hunter.Account do
   end
 
   @doc """
-  Follow a remote user
-
-  ## Parameters
-
-    * `conn` - connection credentials
-    * `uri` - URI of the remote user, in the format of `username@domain`
-
-  """
-  @spec follow_by_uri(Hunter.Client.t(), String.t()) :: Hunter.Account.t()
-  def follow_by_uri(conn, uri) do
-    Config.hunter_api().follow_by_uri(conn, uri)
-  end
-
-  @doc """
   Search for accounts
 
   ## Parameters

--- a/lib/hunter/api.ex
+++ b/lib/hunter/api.ex
@@ -83,17 +83,6 @@ defmodule Hunter.Api do
               Hunter.Account.t()
 
   @doc """
-  Follow a remote user
-
-  ## Parameters
-
-    * `conn` - connection credentials
-    * `uri` - URI of the remote user, in the format of `username@domain`
-
-  """
-  @callback follow_by_uri(conn :: Hunter.Client.t(), id :: non_neg_integer) :: Hunter.Account.t()
-
-  @doc """
   Search for accounts
 
   ## Parameters
@@ -612,16 +601,6 @@ defmodule Hunter.Api do
 
   """
   @callback clear_notification(conn :: Hunter.Client.t(), id :: non_neg_integer) :: boolean
-
-  @doc """
-  Retrieve a user's reports
-
-  ## Parameters
-
-    * `conn` - connection credentials
-
-  """
-  @callback reports(conn :: Hunter.Client.t()) :: [Hunter.Report.t()]
 
   @doc """
   Report a user

--- a/lib/hunter/api/http_client.ex
+++ b/lib/hunter/api/http_client.ex
@@ -37,12 +37,6 @@ defmodule Hunter.Api.HTTPClient do
     |> request!(:accounts, :get, options, conn)
   end
 
-  def follow_by_uri(conn, uri) do
-    "/api/v1/follows"
-    |> process_url(conn)
-    |> request!(:account, :post, %{uri: uri}, conn)
-  end
-
   def search_account(conn, options) do
     "/api/v1/accounts/search"
     |> process_url(conn)
@@ -265,12 +259,6 @@ defmodule Hunter.Api.HTTPClient do
     "/api/v1/notifications/dismiss/#{id}"
     |> process_url(conn)
     |> request!(nil, :post, [], conn)
-  end
-
-  def reports(conn) do
-    "/api/v1/reports"
-    |> process_url(conn)
-    |> request!(:reports, :get, [], conn)
   end
 
   def report(conn, account_id, status_ids, comment) do

--- a/lib/hunter/api/transformer.ex
+++ b/lib/hunter/api/transformer.ex
@@ -40,8 +40,6 @@ defmodule Hunter.Api.Transformer do
 
   def transform(body, :report), do: Poison.decode!(body, as: %Hunter.Report{})
 
-  def transform(body, :reports), do: Poison.decode!(body, as: [%Hunter.Report{}])
-
   def transform(body, :result) do
     Poison.decode!(
       body,

--- a/lib/hunter/api/transformer.ex
+++ b/lib/hunter/api/transformer.ex
@@ -45,7 +45,11 @@ defmodule Hunter.Api.Transformer do
   def transform(body, :result) do
     Poison.decode!(
       body,
-      as: %Hunter.Result{accounts: [%Hunter.Account{}], statuses: [status_nested_struct()]}
+      as: %Hunter.Result{
+        accounts: [%Hunter.Account{}],
+        statuses: [status_nested_struct()],
+        hashtags: [%Hunter.Tag{}]
+      }
     )
   end
 

--- a/lib/hunter/report.ex
+++ b/lib/hunter/report.ex
@@ -22,19 +22,6 @@ defmodule Hunter.Report do
   defstruct [:id, :action_taken]
 
   @doc """
-  Retrieve a user's reports
-
-  ## Parameters
-
-    * `conn` - connection credentials
-
-  """
-  @spec reports(Hunter.Client.t()) :: [Hunter.Report.t()]
-  def reports(conn) do
-    Config.hunter_api().reports(conn)
-  end
-
-  @doc """
   Report a user
 
   ## Parameters

--- a/lib/hunter/result.ex
+++ b/lib/hunter/result.ex
@@ -6,7 +6,7 @@ defmodule Hunter.Result do
 
     * `accounts` - list of matched `Hunter.Account`
     * `statuses` - list of matched `Hunter.Status`
-    * `hashtags` - list of matched hashtags, as strings
+    * `hashtags` - list of matched `Hunter.Tag`
 
   """
   alias Hunter.Config
@@ -14,7 +14,7 @@ defmodule Hunter.Result do
   @type t :: %__MODULE__{
           accounts: [Hunter.Account.t()],
           statuses: [Hunter.Status.t()],
-          hashtags: [String.t()]
+          hashtags: [Hunter.Tag.t()]
         }
 
   @derive [Poison.Encoder]

--- a/test/fixtures/result.json
+++ b/test/fixtures/result.json
@@ -5,5 +5,7 @@
   "statuses": [
     { "id": "103270115826048975", "content": "<p>Testing #elixir</p>", "visibility": "public" }
   ],
-  "hashtags": ["elixir"]
+  "hashtags": [
+    { "name": "elixir", "url": "https://mastodon.example/tags/elixir" }
+  ]
 }

--- a/test/hunter/account_test.exs
+++ b/test/hunter/account_test.exs
@@ -41,15 +41,6 @@ defmodule Hunter.AccountTest do
     assert [%Account{username: "paperswelove"} | _] = Account.following(@conn, 8039)
   end
 
-  test "following a remote user" do
-    expect(Hunter.ApiMock, :follow_by_uri, fn %Hunter.Client{}, _id ->
-      %Account{username: "paperswelove"}
-    end)
-
-    assert %Account{username: "paperswelove"} =
-             Account.follow_by_uri(@conn, "paperswelove@mstdn.io")
-  end
-
   test "updates authenticated user's credentials" do
     expect(Hunter.ApiMock, :update_credentials, fn %Hunter.Client{}, %{note: "new bio"} ->
       %Account{username: "milmazz", note: "new bio"}

--- a/test/hunter/api/transformer_test.exs
+++ b/test/hunter/api/transformer_test.exs
@@ -87,12 +87,15 @@ defmodule Hunter.Api.TransformerTest do
     assert [%Hunter.Report{id: "48914"}] = transform_list("report", :reports)
   end
 
-  test "decodes a search result with nested accounts and statuses" do
+  test "decodes a search result with nested accounts, statuses, and hashtags" do
     result = transform("result", :result)
 
-    assert %Hunter.Result{hashtags: ["elixir"]} = result
+    assert %Hunter.Result{} = result
     assert [%Hunter.Account{username: "milmazz"}] = result.accounts
     assert [%Hunter.Status{visibility: "public"}] = result.statuses
+
+    assert [%Hunter.Tag{name: "elixir", url: "https://mastodon.example/tags/elixir"}] =
+             result.hashtags
   end
 
   test "decodes an attachment" do

--- a/test/hunter/api/transformer_test.exs
+++ b/test/hunter/api/transformer_test.exs
@@ -83,10 +83,6 @@ defmodule Hunter.Api.TransformerTest do
     assert %Hunter.Report{id: "48914", action_taken: false} = transform("report", :report)
   end
 
-  test "decodes a list of reports" do
-    assert [%Hunter.Report{id: "48914"}] = transform_list("report", :reports)
-  end
-
   test "decodes a search result with nested accounts, statuses, and hashtags" do
     result = transform("result", :result)
 

--- a/test/hunter/report_test.exs
+++ b/test/hunter/report_test.exs
@@ -9,14 +9,6 @@ defmodule Hunter.ReportTest do
 
   setup :verify_on_exit!
 
-  test "returns authenticated user's reports" do
-    expect(Hunter.ApiMock, :reports, fn %Hunter.Client{} ->
-      [%Report{id: "48914", action_taken: false}]
-    end)
-
-    assert [%Report{id: "48914"}] = Report.reports(@conn)
-  end
-
   test "reports an account" do
     expect(Hunter.ApiMock, :report, fn %Hunter.Client{}, 8039, [153_452], "spam" ->
       %Report{id: "48915", action_taken: false}

--- a/test/hunter/result_test.exs
+++ b/test/hunter/result_test.exs
@@ -11,9 +11,9 @@ defmodule Hunter.ResultTest do
 
   test "searches for content" do
     expect(Hunter.ApiMock, :search, fn %Hunter.Client{}, "elixir", [] ->
-      %Result{accounts: [], statuses: [], hashtags: ["elixir"]}
+      %Result{accounts: [], statuses: [], hashtags: [%Hunter.Tag{name: "elixir"}]}
     end)
 
-    assert %Result{hashtags: ["elixir"]} = Result.search(@conn, "elixir")
+    assert %Result{hashtags: [%Hunter.Tag{name: "elixir"}]} = Result.search(@conn, "elixir")
   end
 end

--- a/test/integration/mastodon_test.exs
+++ b/test/integration/mastodon_test.exs
@@ -1,7 +1,7 @@
 defmodule Hunter.Integration.MastodonTest do
   use Hunter.IntegrationCase, async: false
 
-  alias Hunter.{Account, Attachment, Instance, Notification, Relationship, Status}
+  alias Hunter.{Account, Attachment, Instance, Notification, Relationship, Result, Status}
 
   @png Base.decode64!(
          "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
@@ -112,5 +112,19 @@ defmodule Hunter.Integration.MastodonTest do
 
     Status.destroy_status(conn, id1)
     Status.destroy_status(conn, id2)
+  end
+
+  test "searches via /api/v2/search returning v2 shapes", %{conn: conn} do
+    %Status{id: id} = Status.create_status(conn, "tagged search probe #hunterci")
+
+    eventually(fn ->
+      result = Result.search(conn, "hunterci")
+      assert Enum.any?(result.hashtags, &match?(%Hunter.Tag{name: "hunterci"}, &1))
+    end)
+
+    people = Result.search(conn, "kadaba")
+    assert Enum.any?(people.accounts, &(&1.username == "kadaba"))
+
+    Status.destroy_status(conn, id)
   end
 end


### PR DESCRIPTION
Closes #106. PR 2 of 2, stacked on #108.

- `Result.hashtags` now decodes as `[Hunter.Tag.t()]` — the actual `/api/v2/search` shape (breaking, 0.6.0)
- Removed `follow_by_uri` (`POST /api/v1/follows` was removed in Mastodon 4.0) and `reports/1` (`GET /api/v1/reports` removed); `report/4` filing is unaffected (breaking, 0.6.0)
- New live integration test covers v2 search (hashtag + account facets; status facet needs Elasticsearch, which the CI stack intentionally omits)
- Also removes the README examples for the two deleted functions (caught in review)

Note: #106's claim that `Result.search` targets `/api/v1/search` was stale — the code already used v2. The real gaps were the query-param transport (fixed by the base PR) and the hashtag shape (fixed here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)