### PR TITLE
Auth fixes: request registered scopes on log_in; rename to access_token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
     - Removed `Hunter.reports/1` / `Hunter.Report.reports/1`: Mastodon removed
       `GET /api/v1/reports`. Filing reports via `Hunter.report/4` still works.
 
+  * Bug fixes
+    - GET/DELETE request options now travel as query-string parameters instead
+      of JSON request bodies, which proxies routinely drop ([#74])
+
 ## v0.5.1
 
   * Bug fixes
@@ -80,3 +84,5 @@
  ## v0.1.0
 
   * Initial release
+
+[#74]: https://github.com/milmazz/hunter/issues/74

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
       use `Hunter.follow/2` instead.
     - Removed `Hunter.reports/1` / `Hunter.Report.reports/1`: Mastodon removed
       `GET /api/v1/reports`. Filing reports via `Hunter.report/4` still works.
+    - `Hunter.Client` field `bearer_token` was renamed to `access_token` for
+      consistency with other Mastodon client libraries; update
+      `Hunter.Client.new(bearer_token: …)` calls to `access_token:` ([#101])
 
   * Bug fixes
     - GET/DELETE request options now travel as query-string parameters instead
@@ -86,3 +89,4 @@
   * Initial release
 
 [#74]: https://github.com/milmazz/hunter/issues/74
+[#101]: https://github.com/milmazz/hunter/issues/101

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@
   * Bug fixes
     - GET/DELETE request options now travel as query-string parameters instead
       of JSON request bodies, which proxies routinely drop ([#74])
+    - `Hunter.log_in/4` now requests the scopes the app was registered with;
+      previously the token silently fell back to Mastodon's default `read`
+      scope, making every write action fail with "This action is outside the
+      authorized scopes" ([#100]). Re-run `create_app` once to refresh saved
+      credentials created by older hunter versions.
 
 ## v0.5.1
 
@@ -89,4 +94,5 @@
   * Initial release
 
 [#74]: https://github.com/milmazz/hunter/issues/74
+[#100]: https://github.com/milmazz/hunter/issues/100
 [#101]: https://github.com/milmazz/hunter/issues/101

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,9 @@ Below are the guidelines for working on Pull Requests:
 
   Requires Docker. The stack is disposable: `docker compose -f docker-compose.ci.yml down -v`.
   You can also point the suite at any instance you own by exporting
-  `HUNTER_BASE_URL`, `HUNTER_TOKEN` and `HUNTER_TOKEN2` yourself.
+  `HUNTER_BASE_URL`, `HUNTER_TOKEN`, `HUNTER_TOKEN2` and `HUNTER_PASSWORD2`
+  (the account password for the second user, used by the auth-flow test)
+  yourself.
 
 ## New features or bug fixes
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Once you have a registered app you can do the following:
 ```elixir
 iex> conn = Hunter.log_in(app, "jdoe@example.com", "your_password", "https://example.com")
 %Hunter.Client{base_url: "https://example.com",
- bearer_token: "123456"}
+ access_token: "123456"}
 ```
 
 Or, if you want to use [OAuth code](https://docs.joinmastodon.org/methods/apps/oauth/) for authentication:
@@ -73,7 +73,7 @@ Or, if you want to use [OAuth code](https://docs.joinmastodon.org/methods/apps/o
 ```elixir
 iex> conn = Hunter.log_in_oauth(app, "123456code", "https://example.com")
 %Hunter.Client{base_url: "https://example.com",
- bearer_token: "123456"}
+ access_token: "123456"}
 ```
 
 Now you can use `conn` in any API request.
@@ -82,9 +82,9 @@ If you don't want to register an application but you already know your
 *instance* and your *bearer token* you can do the following:
 
 ```elixir
-iex> conn = Hunter.new([base_url: "https://example.com", bearer_token: "123456"])
+iex> conn = Hunter.new([base_url: "https://example.com", access_token: "123456"])
 %Hunter.Client{base_url: "https://example.com",
- bearer_token: "123456"}
+ access_token: "123456"}
 ```
 
 Returns `Hunter.Client` details.

--- a/docs/superpowers/plans/2026-07-07-auth-fixes.md
+++ b/docs/superpowers/plans/2026-07-07-auth-fixes.md
@@ -1,0 +1,335 @@
+# Auth Fixes Implementation Plan (#100 + #101)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `log_in/4` requests the app's registered scopes so tokens can write (#100), and `Hunter.Client.bearer_token` becomes `access_token` (#101) — one branch, one PR, 0.6.0.
+
+**Architecture:** Rename first (Task 2) so all later code uses the new field. Then `Hunter.Application` grows a `scopes` field that `create_app` fills with the *requested* scopes (Task 3), and `log_in` joins them into the password-grant `scope` parameter, omitting it when `scopes` is nil/empty so stale saved credentials keep today's behavior (Task 4). The regression proof is a live integration test running the README auth flow end-to-end (Task 5).
+
+**Tech Stack:** Elixir/ExUnit, Mox, Poison persistence, the docker-compose Mastodon stack (`tootctl` password reset for a known login).
+
+**Spec:** `docs/superpowers/specs/2026-07-07-auth-fixes-design.md`
+
+## Global Constraints
+
+- Branch `auth-fixes` off `main` (exists, spec committed at e18acf1). Single PR, base `main`.
+- Hard rename: after Task 2, `git grep -n "bearer_token" -- lib test README.md` returns nothing (CHANGELOG history may keep old mentions; none exist today).
+- `scope` parameter omitted from the token payload when `Application.scopes` is `nil` or `[]` (old saved credentials keep current behavior).
+- Every commit passes `mix compile --warnings-as-errors && mix test && mix format --check-formatted && mix credo --strict`; run `mix dialyzer` once in Task 6 before pushing (struct/type changes).
+- Integration verification: `./scripts/ci/setup_mastodon.sh` then `bash -c 'source scripts/ci/.env.hunter && mix test --only integration'`.
+- Commit messages end with `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`; PR body ends with `🤖 Generated with [Claude Code](https://claude.com/claude-code)` and says `Fixes #100. Closes #101.`
+
+---
+
+### Task 1: restore the CHANGELOG entry lost in the #109 rebase-merge
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Add the Bug fixes block** — under `## Unreleased`, after the `* Breaking changes` block (currently ending with the `reports/1` bullet around line 14), insert:
+
+```markdown
+
+  * Bug fixes
+    - GET/DELETE request options now travel as query-string parameters instead
+      of JSON request bodies, which proxies routinely drop ([#74])
+```
+
+and at the bottom of the file add the link reference (match the file's existing reference style; if none exists, plain `[#74]: https://github.com/milmazz/hunter/issues/74` on its own line at the end):
+
+```markdown
+[#74]: https://github.com/milmazz/hunter/issues/74
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "restore #74 changelog entry dropped in the #109 rebase-merge
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+### Task 2: #101 hard rename `bearer_token` → `access_token`
+
+**Files:**
+- Modify: `lib/hunter/client.ex` (struct, @type, docs), `lib/hunter/api/http_client.ex` (`get_headers/1`, `log_in/4`, `log_in_oauth/3` constructors), doc examples in `lib/hunter.ex`, `lib/hunter/instance.ex`, `lib/hunter/account.ex`, `lib/hunter/card.ex`, `README.md`, `CHANGELOG.md`
+- Modify (tests): `test/support/integration_case.ex` and every unit test file constructing a client: `test/hunter/{account,attachment,card,client,context,domain,instance,notification,relationship,report,result,status}_test.exs`
+
+**Interfaces:**
+- Produces: `%Hunter.Client{base_url: String.t(), access_token: String.t()}` — Tasks 4-5 build clients with `access_token:`.
+
+- [ ] **Step 1: Mechanical rename** — replace the atom/field `bearer_token` with `access_token` in every file above. The complete list of change kinds:
+  - `lib/hunter/client.ex`: `defstruct [:base_url, :access_token]`, the `@type t` field, and both mentions in the moduledoc/`new/1` `## Options` docs.
+  - `lib/hunter/api/http_client.ex`: `defp get_headers(%Hunter.Client{access_token: token})`, and the two `%Hunter.Client{base_url: base_url, access_token: response["access_token"]}` constructors in `log_in/4` / `log_in_oauth/3`.
+  - Doc examples (`iex> Hunter.Client.new(bearer_token: …)`) in `lib/hunter.ex`, `lib/hunter/instance.ex`, `lib/hunter/account.ex`, `lib/hunter/card.ex` → `access_token:`.
+  - Every test file's `@conn Hunter.Client.new(base_url: "https://example.com", access_token: "123456")`, `client_test.exs`'s construction + assertion (`%Client{base_url: …, access_token: "123456"}`), and `integration_case.ex`'s two `Hunter.Client.new(base_url: base_url, access_token: token)` calls.
+  - `README.md`: every `bearer_token` occurrence in examples/prose.
+
+Use per-file edits, not a blind repo-wide sed — the string `"access_token"` (the JSON response key in `http_client.ex`) must stay untouched, and CHANGELOG/docs specs are out of scope.
+
+- [ ] **Step 2: Verify the rename is total**
+
+Run: `git grep -n "bearer_token" -- lib test README.md`
+Expected: no output.
+
+- [ ] **Step 3: CHANGELOG breaking entry** — append to the `* Breaking changes` list in `## Unreleased`:
+
+```markdown
+    - `Hunter.Client` field `bearer_token` was renamed to `access_token` for
+      consistency with other Mastodon client libraries; update
+      `Hunter.Client.new(bearer_token: …)` calls to `access_token:` ([#101])
+```
+
+with `[#101]: https://github.com/milmazz/hunter/issues/101` added to the link references.
+
+- [ ] **Step 4: Full gate**
+
+Run: `mix compile --warnings-as-errors && mix test && mix format --check-formatted && mix credo --strict`
+Expected: green — 4 doctests, 76 tests (`--warnings-as-errors` plus the doctests catch any straggler).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "rename Client.bearer_token to access_token
+
+BREAKING: aligns with other Mastodon client libraries (#101).
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+### Task 3: `Hunter.Application.scopes` + `create_app` stores requested scopes (TDD)
+
+**Files:**
+- Modify: `lib/hunter/application.ex` (struct/@type/docs), `lib/hunter/api/http_client.ex:70-81` (`create_app/5`)
+- Test: `test/hunter/application_test.exs`
+
+**Interfaces:**
+- Produces: `%Hunter.Application{id, client_id, client_secret, scopes :: [String.t()] | nil}` — Task 4's `log_in` reads `scopes`; persistence via the existing `save_credentials`/`load_credentials` picks the field up automatically (Poison encodes/decodes struct fields).
+
+- [ ] **Step 1: Extend the persistence tests (failing first)** — in `test/hunter/application_test.exs`, the existing "store credentials" and "load persisted" tests build `%Hunter.Application{…}` values; add `scopes: ["read", "write"]` to the constructed app in BOTH tests and assert the loaded struct round-trips it:
+
+```elixir
+      assert %Hunter.Application{scopes: ["read", "write"]} = loaded
+```
+
+(match the test file's existing local variable names — read the file first; the assertion target is whatever `load_credentials` returns there).
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `mix test test/hunter/application_test.exs`
+Expected: FAIL — `scopes` is not a key of `Hunter.Application` (KeyError at construction).
+
+- [ ] **Step 3: Add the field** — `lib/hunter/application.ex`:
+
+```elixir
+  defstruct [:id, :client_id, :client_secret, :scopes]
+```
+
+extend the `@type t` with `scopes: [String.t()] | nil` and add a `* scopes - scopes requested when the app was registered` line to the fields doc.
+
+- [ ] **Step 4: Store requested scopes in `create_app`** — `lib/hunter/api/http_client.ex`:
+
+```elixir
+  def create_app(name, redirect_uri, scopes, website, base_url) do
+    payload = %{
+      client_name: name,
+      redirect_uris: redirect_uri,
+      scopes: Enum.join(scopes, " "),
+      website: website
+    }
+
+    app =
+      "/api/v1/apps"
+      |> process_url(base_url)
+      |> request!(:application, :post, payload)
+
+    %Hunter.Application{app | scopes: scopes}
+  end
+```
+
+(The requested list is authoritative — the v1 apps response cannot be trusted to echo scopes across server versions.)
+
+- [ ] **Step 5: Full gate and commit**
+
+Run: `mix compile --warnings-as-errors && mix test && mix format --check-formatted && mix credo --strict`
+Expected: green.
+
+```bash
+git add lib/hunter/application.ex lib/hunter/api/http_client.ex test/hunter/application_test.exs
+git commit -m "record requested scopes on Hunter.Application
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+### Task 4: `log_in/4` sends the app's scopes (#100 fix)
+
+**Files:**
+- Modify: `lib/hunter/api/http_client.ex` (`log_in/4`, around line 288), `CHANGELOG.md`
+
+**Interfaces:**
+- Consumes: `Hunter.Application.scopes` from Task 3.
+
+- [ ] **Step 1: Rewrite `log_in/4`**
+
+```elixir
+  def log_in(%Hunter.Application{} = app, username, password, base_url) do
+    payload = %{
+      client_id: app.client_id,
+      client_secret: app.client_secret,
+      grant_type: "password",
+      username: username,
+      password: password
+    }
+
+    payload =
+      case app.scopes do
+        scopes when is_list(scopes) and scopes != [] ->
+          Map.put(payload, :scope, Enum.join(scopes, " "))
+
+        _ ->
+          payload
+      end
+
+    response =
+      "/oauth/token"
+      |> process_url(base_url)
+      |> request!(nil, :post, payload)
+
+    %Hunter.Client{base_url: base_url, access_token: response["access_token"]}
+  end
+```
+
+(Behavior for `scopes: nil`/`[]` — the parameter is omitted, byte-identical to today, so stale saved credential files keep working. This is unit-untestable without a network; the live proof is Task 5.)
+
+- [ ] **Step 2: CHANGELOG bug-fix entry** — append under the `* Bug fixes` block from Task 1:
+
+```markdown
+    - `Hunter.log_in/4` now requests the scopes the app was registered with;
+      previously the token silently fell back to Mastodon's default `read`
+      scope, making every write action fail with "This action is outside the
+      authorized scopes" ([#100]). Re-run `create_app` once to refresh saved
+      credentials created by older hunter versions.
+```
+
+with `[#100]: https://github.com/milmazz/hunter/issues/100` in the link references.
+
+- [ ] **Step 3: Full gate and commit**
+
+Run: `mix compile --warnings-as-errors && mix test && mix format --check-formatted && mix credo --strict`
+Expected: green.
+
+```bash
+git add lib/hunter/api/http_client.ex CHANGELOG.md
+git commit -m "request the app's registered scopes in the password grant
+
+Fixes the read-only tokens behind issue #100.
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+### Task 5: known password in the stack + live README-flow regression test
+
+**Files:**
+- Modify: `scripts/ci/setup_mastodon.sh`, `test/support/integration_case.ex`, `test/integration/mastodon_test.exs`
+
+**Interfaces:**
+- Produces: `HUNTER_PASSWORD2` env var (kadaba's password) in `scripts/ci/.env.hunter` and `$GITHUB_ENV`; `password2` in the integration context.
+
+- [ ] **Step 1: setup script** — in `scripts/ci/setup_mastodon.sh`, after `TOKEN2=$(mint_token kadaba)`, add:
+
+```bash
+PASSWORD2=$($COMPOSE exec -T web bin/tootctl accounts modify kadaba --reset-password \
+  | awk '/New password:/ {print $3}')
+```
+
+and extend both output blocks: add `export HUNTER_PASSWORD2=$PASSWORD2` to the `$HUNTER_ENV` heredoc and `echo "HUNTER_PASSWORD2=$PASSWORD2"` to the `$GITHUB_ENV` block.
+
+- [ ] **Step 2: integration case** — in `test/support/integration_case.ex` `setup_all`, add `password2 = fetch_env!("HUNTER_PASSWORD2")` next to the other three, and `password2: password2` to the returned context keyword list. Update the module's `@moduledoc` env-var list to mention it.
+
+- [ ] **Step 3: the regression test** — append to `test/integration/mastodon_test.exs`:
+
+```elixir
+  test "README auth flow: create_app + log_in yields a token that can write", %{
+    conn: conn,
+    password2: password2
+  } do
+    app =
+      Hunter.create_app(
+        "hunter-auth-#{System.unique_integer([:positive])}",
+        "urn:ietf:wg:oauth:2.0:oob",
+        ["read", "write"],
+        nil,
+        api_base_url: conn.base_url
+      )
+
+    assert %Hunter.Application{scopes: ["read", "write"]} = app
+
+    logged_in = Hunter.log_in(app, "kadaba@example.com", password2, conn.base_url)
+    assert %Hunter.Client{access_token: token} = logged_in
+    assert is_binary(token)
+
+    %Status{id: id} = Status.create_status(logged_in, "auth flow works #hunterci")
+    Status.destroy_status(logged_in, id)
+  end
+```
+
+Before finalizing, confirm `Hunter.create_app/5` and `Hunter.log_in/4` delegate with these exact signatures (`grep -n "create_app\|def log_in\|defdelegate log_in" lib/hunter.ex`); adjust the calls if the top-level arity differs.
+
+- [ ] **Step 4: Run live** (this test FAILS against the pre-Task-4 code with the #100 error — if you want the red-state proof, run it once with Task 4's `log_in` change stashed; otherwise proceed):
+
+Run: `./scripts/ci/setup_mastodon.sh && bash -c 'source scripts/ci/.env.hunter && mix test --only integration'`
+Expected: 10 tests, 0 failures. (The setup script must be re-run so `.env.hunter` gains `HUNTER_PASSWORD2` — the older env file will make `setup_all` raise its helpful error.)
+
+- [ ] **Step 5: Unit gate and commit**
+
+Run: `mix test && mix format --check-formatted && mix credo --strict`
+Expected: green (integration excluded).
+
+```bash
+git add scripts/ci/setup_mastodon.sh test/support/integration_case.ex test/integration/mastodon_test.exs
+git commit -m "cover the README auth flow live: create_app, log_in, write
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+### Task 6: dialyzer, PR, follow-up issue
+
+- [ ] **Step 1: Dialyzer** (struct/type changes across Tasks 2-4):
+
+Run: `mix dialyzer`
+Expected: clean. Fix any finding before pushing (likely candidates: the changed `log_in/4` head or the new `scopes` type).
+
+- [ ] **Step 2: Push and open the PR**
+
+```bash
+git push -u origin auth-fixes
+gh pr create --base main --title "Auth fixes: request registered scopes on log_in; rename to access_token" --body "$(cat <<'EOF'
+Fixes #100. Closes #101.
+
+- `log_in/4` now sends the app's registered scopes in the password grant. Previously the `scope` parameter was omitted, so Doorkeeper granted Mastodon's default `read` scope and every write action failed with "This action is outside the authorized scopes" — reproduced and verified live against Mastodon v4.3.8. `Hunter.Application` records the requested scopes (persisted by `save?: true`); stale credential files (`scopes: nil`) keep the old behavior until `create_app` is re-run.
+- BREAKING: `Hunter.Client.bearer_token` → `access_token` (#101), aligned with other Mastodon client libraries.
+- New live integration test covers the README auth flow end to end (create_app → log_in → post → delete), using a known password minted by the setup script (`HUNTER_PASSWORD2`).
+- Restores the #74 changelog entry dropped in the #109 rebase-merge.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: File the deferred `log_in_oauth` issue**
+
+```bash
+gh issue create --title "log_in_oauth: token exchange sends no redirect_uri" --body "$(cat <<'EOF'
+Noticed while fixing #100: `Hunter.Api.HTTPClient.log_in_oauth/3` exchanges the authorization code without a `redirect_uri` parameter. Doorkeeper requires the token request's `redirect_uri` to match the authorization request's for the authorization_code grant, so this flow likely fails against real servers. Unverified (needs a browser authorization dance) — verify against the docker stack and fix; scopes for this grant come from the authorization itself, so no scope parameter is needed.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 4: Watch checks**
+
+Run: `gh pr checks --watch`
+Expected: all 5 jobs green — note the integration job re-provisions from scratch, which exercises the new `HUNTER_PASSWORD2` script path in CI.

--- a/docs/superpowers/specs/2026-07-07-auth-fixes-design.md
+++ b/docs/superpowers/specs/2026-07-07-auth-fixes-design.md
@@ -1,0 +1,97 @@
+# Auth Fixes Design: Token Scopes (#100) + access_token Rename (#101)
+
+**Date:** 2026-07-07
+**Status:** Approved
+**Related:** [issue #100](https://github.com/milmazz/hunter/issues/100),
+[issue #101](https://github.com/milmazz/hunter/issues/101)
+
+## Goal
+
+Make `log_in/4` request the scopes the app was registered with, so tokens can
+actually write (#100), and rename `Hunter.Client.bearer_token` to
+`access_token` for ecosystem consistency (#101). One branch (`auth-fixes` off
+`main`), one PR, shipping in the 0.6.0 breaking window.
+
+## Root cause of #100 (diagnosed live, 2026-07-07)
+
+`Hunter.Api.HTTPClient.log_in/4` omits `scope` from the `/oauth/token`
+password-grant payload. Doorkeeper then grants Mastodon's **default scope,
+`read`**, regardless of the app's registered scopes. Reproduced against a
+local Mastodon v4.3.8: token request without `scope` → `granted scope: read`
+→ `POST /api/v1/statuses` returns exactly the issue's error ("This action is
+outside the authorized scopes"). Same request with
+`scope: "read write follow"` → write succeeds.
+
+Constraint discovered: `Hunter.Application` does not store the scopes it was
+created with, so `log_in` has nothing to re-request today.
+
+## Decisions (user-approved 2026-07-07)
+
+1. **#100 fix shape:** store scopes on `Hunter.Application` (new `scopes`
+   field, persisted by `save?: true`); `log_in` sends them. Not an explicit
+   `log_in` argument; not hardcoded scopes.
+2. **#101 shape:** hard rename, no compatibility shim. Compile-time breakage
+   is loud and documented.
+3. Single PR; rename lands first so the #100 code is written against the new
+   field name.
+4. `log_in_oauth`'s suspected missing `redirect_uri` is out of scope — file a
+   separate issue instead of widening this PR (verification requires a
+   browser authorization dance).
+
+## Part 0: restore the lost CHANGELOG entry
+
+The rebase-merge of PR #109 dropped its final commit (`cb80130`). First
+commit of this branch restores the Unreleased "Bug fixes" bullet for #74
+(GET/DELETE options as query params) with its `[#74]` link reference.
+
+## Part 1: #101 hard rename
+
+- `Hunter.Client`: `defstruct [:base_url, :access_token]`, `@type t`, and
+  moduledoc/`new/1` docs updated.
+- `Hunter.Api.HTTPClient`: `get_headers/1` matches
+  `%Hunter.Client{access_token: token}`; `log_in/4` and `log_in_oauth/3`
+  build `%Hunter.Client{base_url: base_url, access_token: …}`.
+- All test files constructing `Hunter.Client.new(bearer_token: …)` switch to
+  `access_token:` (≈12 unit test files plus
+  `test/support/integration_case.ex`).
+- README examples updated (`grep -rn bearer_token` must come up empty
+  repo-wide except CHANGELOG history).
+- CHANGELOG breaking entry: rename, with the one-line migration
+  (`bearer_token:` → `access_token:`).
+
+## Part 2: #100 fix
+
+- `Hunter.Application` gains `scopes` (list of `String.t()`, default `nil`):
+  struct, `@type`, field docs.
+- `HTTPClient.create_app/5` puts the **requested** scopes list into the
+  returned struct after decoding (the v1 apps response cannot be trusted to
+  echo scopes across server versions). Persisted credentials
+  (`save?: true` → Poison-encoded file) therefore include scopes; old files
+  load with `scopes: nil`.
+- `HTTPClient.log_in/4` payload gains `scope: Enum.join(scopes, " ")` when
+  the app's scopes is a non-empty list; the parameter is omitted for `nil`
+  or `[]` (byte-compatible with old saved credentials — current behavior).
+- CHANGELOG bug-fix entry referencing #100.
+
+## Testing
+
+- **Integration (the #100 regression test):** new test doing the README
+  flow — `Hunter.create_app/5` → `Hunter.log_in/4` → `create_status` →
+  `destroy_status` — which fails with the exact #100 error before the fix.
+  Requires a known password: `scripts/ci/setup_mastodon.sh` gains a
+  `tootctl accounts modify kadaba --reset-password` step and exports
+  `HUNTER_PASSWORD2` (env file + `$GITHUB_ENV`). The test skips nothing:
+  password comes from the same env contract as the tokens.
+- **Unit:** application persistence tests extended for the scopes round-trip
+  (create → save → load); a Mox test pinning that `log_in` receives the app
+  with scopes intact; rename covered by the entire existing suite compiling
+  and passing (`--warnings-as-errors` catches stragglers).
+- Full gate per commit: compile --warnings-as-errors, test, format
+  --check-formatted, credo --strict; dialyzer once at the end (struct/type
+  changes).
+
+## Out of scope
+
+- `log_in_oauth` redirect_uri verification/fix — new issue to file.
+- Any other 0.6.0 items (#107 follow-ups, #110 domain-block auth, #103
+  Finch).

--- a/lib/hunter.ex
+++ b/lib/hunter.ex
@@ -237,7 +237,7 @@ defmodule Hunter do
   ## Options
 
     * `base_url` - URL of the instance you want to connect to
-    * `bearer_token` - [String] OAuth access token for your authenticated user
+    * `access_token` - [String] OAuth access token for your authenticated user
 
   """
   @spec new(Keyword.t()) :: Hunter.Client.t()

--- a/lib/hunter/account.ex
+++ b/lib/hunter/account.ex
@@ -83,8 +83,8 @@ defmodule Hunter.Account do
 
   ## Examples
 
-        iex> conn = Hunter.new([base_url: "https://social.lou.lt", bearer_token: "123456"])
-        %Hunter.Client{base_url: "https://social.lou.lt", bearer_token: "123456"}
+        iex> conn = Hunter.new([base_url: "https://social.lou.lt", access_token: "123456"])
+        %Hunter.Client{base_url: "https://social.lou.lt", access_token: "123456"}
         iex> Hunter.Account.verify_credentials(conn)
         %Hunter.Account{acct: "milmazz",
                 avatar: "https://social.lou.lt/avatars/original/missing.png",

--- a/lib/hunter/api/http_client.ex
+++ b/lib/hunter/api/http_client.ex
@@ -289,19 +289,23 @@ defmodule Hunter.Api.HTTPClient do
     |> request!(:card, :get, [], conn)
   end
 
-  def log_in(
-        %Hunter.Application{client_id: client_id, client_secret: client_secret},
-        username,
-        password,
-        base_url
-      ) do
+  def log_in(%Hunter.Application{} = app, username, password, base_url) do
     payload = %{
-      client_id: client_id,
-      client_secret: client_secret,
+      client_id: app.client_id,
+      client_secret: app.client_secret,
       grant_type: "password",
       username: username,
       password: password
     }
+
+    payload =
+      case app.scopes do
+        scopes when is_list(scopes) and scopes != [] ->
+          Map.put(payload, :scope, Enum.join(scopes, " "))
+
+        _ ->
+          payload
+      end
 
     response =
       "/oauth/token"

--- a/lib/hunter/api/http_client.ex
+++ b/lib/hunter/api/http_client.ex
@@ -75,9 +75,13 @@ defmodule Hunter.Api.HTTPClient do
       website: website
     }
 
-    "/api/v1/apps"
-    |> process_url(base_url)
-    |> request!(:application, :post, payload)
+    %Hunter.Application{} =
+      app =
+      "/api/v1/apps"
+      |> process_url(base_url)
+      |> request!(:application, :post, payload)
+
+    %Hunter.Application{app | scopes: scopes}
   end
 
   def upload_media(conn, file, options) do

--- a/lib/hunter/api/http_client.ex
+++ b/lib/hunter/api/http_client.ex
@@ -304,7 +304,7 @@ defmodule Hunter.Api.HTTPClient do
       |> process_url(base_url)
       |> request!(nil, :post, payload)
 
-    %Hunter.Client{base_url: base_url, bearer_token: response["access_token"]}
+    %Hunter.Client{base_url: base_url, access_token: response["access_token"]}
   end
 
   def log_in_oauth(
@@ -324,7 +324,7 @@ defmodule Hunter.Api.HTTPClient do
       |> process_url(base_url)
       |> request!(nil, :post, payload)
 
-    %Hunter.Client{base_url: base_url, bearer_token: response["access_token"]}
+    %Hunter.Client{base_url: base_url, access_token: response["access_token"]}
   end
 
   def blocked_domains(conn, options) do
@@ -360,7 +360,7 @@ defmodule Hunter.Api.HTTPClient do
 
   defp get_headers(nil), do: []
 
-  defp get_headers(%Hunter.Client{bearer_token: token}) do
+  defp get_headers(%Hunter.Client{access_token: token}) do
     [{:Authorization, "Bearer #{token}"}]
   end
 

--- a/lib/hunter/application.ex
+++ b/lib/hunter/application.ex
@@ -10,6 +10,7 @@ defmodule Hunter.Application do
     * `id` -  identifier
     * `client_id` - client id
     * `client_secret` - client secret
+    * `scopes` - scopes requested when the app was registered
 
   """
   alias Hunter.Config
@@ -17,11 +18,12 @@ defmodule Hunter.Application do
   @type t :: %__MODULE__{
           id: non_neg_integer,
           client_id: String.t(),
-          client_secret: String.t()
+          client_secret: String.t(),
+          scopes: [String.t()] | nil
         }
 
   @derive [Poison.Encoder]
-  defstruct [:id, :client_id, :client_secret]
+  defstruct [:id, :client_id, :client_secret, :scopes]
 
   @doc """
   Register a new OAuth client app on the target instance

--- a/lib/hunter/card.ex
+++ b/lib/hunter/card.ex
@@ -64,8 +64,8 @@ defmodule Hunter.Card do
 
   ## Examples
 
-      iex> conn = Hunter.new([base_url: "https://social.lou.lt", bearer_token: "123456"])
-      %Hunter.Client{base_url: "https://social.lou.lt", bearer_token: "123456"}
+      iex> conn = Hunter.new([base_url: "https://social.lou.lt", access_token: "123456"])
+      %Hunter.Client{base_url: "https://social.lou.lt", access_token: "123456"}
       iex> Hunter.Card.card_by_status(conn, 118_635)
       %Hunter.Card{description: "hunter - A Elixir client for Mastodon, a GNU Social compatible micro-blogging service",
                 image: "https://social.lou.lt/system/preview_cards/images/000/000/378/original/34700?1491626499",

--- a/lib/hunter/client.ex
+++ b/lib/hunter/client.ex
@@ -7,11 +7,11 @@ defmodule Hunter.Client do
 
   @type t :: %__MODULE__{
           base_url: String.t(),
-          bearer_token: String.t()
+          access_token: String.t()
         }
 
   @derive [Poison.Encoder]
-  defstruct [:base_url, :bearer_token]
+  defstruct [:base_url, :access_token]
 
   @doc """
   Initializes a client
@@ -19,7 +19,7 @@ defmodule Hunter.Client do
   ## Options
 
     * `base_url` - URL of the instance you want to connect to
-    * `bearer_token` - [String] OAuth access token for your authenticated user
+    * `access_token` - [String] OAuth access token for your authenticated user
 
   """
   @spec new(Keyword.t()) :: Hunter.Client.t()

--- a/lib/hunter/instance.ex
+++ b/lib/hunter/instance.ex
@@ -38,8 +38,8 @@ defmodule Hunter.Instance do
 
   ## Examples
 
-      iex> conn = Hunter.new([base_url: "https://social.lou.lt", bearer_token: "123456"])
-      %Hunter.Client{base_url: "https://social.lou.lt", bearer_token: "123456"}
+      iex> conn = Hunter.new([base_url: "https://social.lou.lt", access_token: "123456"])
+      %Hunter.Client{base_url: "https://social.lou.lt", access_token: "123456"}
       iex> Hunter.Instance.instance_info(conn)
       %Hunter.Instance{description: "Mostly French  instance - <a href=\\"/about/more#rules\\">Read full description</a> for rules.",
                 email: "maxime+mastodon@melinon.fr", title: "Loultstodon",

--- a/scripts/ci/setup_mastodon.sh
+++ b/scripts/ci/setup_mastodon.sh
@@ -89,10 +89,14 @@ mint_token() {
 TOKEN1=$(mint_token hunter)
 TOKEN2=$(mint_token kadaba)
 
+PASSWORD2=$($COMPOSE exec -T web bin/tootctl accounts modify kadaba --reset-password \
+  | awk '/New password:/ {print $3}')
+
 cat > "$HUNTER_ENV" <<EOF
 export HUNTER_BASE_URL=https://localhost:3000
 export HUNTER_TOKEN=$TOKEN1
 export HUNTER_TOKEN2=$TOKEN2
+export HUNTER_PASSWORD2=$PASSWORD2
 EOF
 
 if [ -n "${GITHUB_ENV:-}" ]; then
@@ -100,6 +104,7 @@ if [ -n "${GITHUB_ENV:-}" ]; then
     echo "HUNTER_BASE_URL=https://localhost:3000"
     echo "HUNTER_TOKEN=$TOKEN1"
     echo "HUNTER_TOKEN2=$TOKEN2"
+    echo "HUNTER_PASSWORD2=$PASSWORD2"
   } >> "$GITHUB_ENV"
 fi
 

--- a/test/hunter/account_test.exs
+++ b/test/hunter/account_test.exs
@@ -5,7 +5,7 @@ defmodule Hunter.AccountTest do
 
   alias Hunter.Account
 
-  @conn Hunter.Client.new(base_url: "https://example.com", bearer_token: "123456")
+  @conn Hunter.Client.new(base_url: "https://example.com", access_token: "123456")
 
   setup :verify_on_exit!
 

--- a/test/hunter/application_test.exs
+++ b/test/hunter/application_test.exs
@@ -23,7 +23,12 @@ defmodule Hunter.ApplicationTest do
 
   test "should allow to store credentials on home directory" do
     expect(Hunter.ApiMock, :create_app, fn _client, _redirect, _scopes, _website, _opts ->
-      %Hunter.Application{client_id: "1234567890", client_secret: "1234567890", id: 1234}
+      %Hunter.Application{
+        client_id: "1234567890",
+        client_secret: "1234567890",
+        id: 1234,
+        scopes: ["read"]
+      }
     end)
 
     home = Hunter.Config.home()
@@ -31,8 +36,12 @@ defmodule Hunter.ApplicationTest do
     Application.put_env(:hunter, :home, tmp_dir)
     app_name = "hunter"
 
-    assert %Hunter.Application{client_id: "1234567890", client_secret: "1234567890", id: 1234} =
-             result =
+    assert %Hunter.Application{
+             client_id: "1234567890",
+             client_secret: "1234567890",
+             id: 1234,
+             scopes: ["read"]
+           } =
              Hunter.Application.create_app(
                app_name,
                "urn:ietf:wg:oauth:2.0:oob",
@@ -42,7 +51,7 @@ defmodule Hunter.ApplicationTest do
                api_base_url: "https://example.com"
              )
 
-    assert result == Hunter.Application.load_credentials(app_name)
+    assert %Hunter.Application{scopes: ["read"]} = Hunter.Application.load_credentials(app_name)
     Application.put_env(:hunter, :home, home)
   end
 
@@ -53,13 +62,19 @@ defmodule Hunter.ApplicationTest do
     app_name = "load"
     Application.put_env(:hunter, :home, tmp_dir)
 
-    expected = %{id: 1234, client_secret: "1234567890", client_id: "1234567890"}
+    expected = %{
+      id: 1234,
+      client_secret: "1234567890",
+      client_id: "1234567890",
+      scopes: ["read", "write"]
+    }
 
     unless File.exists?(app_dir), do: File.mkdir_p!(app_dir)
 
     File.write!("#{app_dir}/#{app_name}.json", Poison.encode!(expected))
 
-    assert %Hunter.Application{} = app = Hunter.Application.load_credentials(app_name)
+    assert %Hunter.Application{scopes: ["read", "write"]} =
+             app = Hunter.Application.load_credentials(app_name)
 
     assert Map.equal?(Map.from_struct(app), expected)
 

--- a/test/hunter/attachment_test.exs
+++ b/test/hunter/attachment_test.exs
@@ -5,7 +5,7 @@ defmodule Hunter.AttachmentTest do
 
   alias Hunter.Attachment
 
-  @conn Hunter.Client.new(base_url: "https://example.com", bearer_token: "123456")
+  @conn Hunter.Client.new(base_url: "https://example.com", access_token: "123456")
 
   setup :verify_on_exit!
 

--- a/test/hunter/card_test.exs
+++ b/test/hunter/card_test.exs
@@ -12,7 +12,7 @@ defmodule Hunter.CardTest do
       %Card{title: "milmazz/hunter"}
     end)
 
-    conn = Hunter.Client.new(base_url: "https://example.com", bearer_token: "123456")
+    conn = Hunter.Client.new(base_url: "https://example.com", access_token: "123456")
     assert %Card{title: "milmazz/hunter"} = Card.card_by_status(conn, 118_635)
   end
 end

--- a/test/hunter/client_test.exs
+++ b/test/hunter/client_test.exs
@@ -5,9 +5,9 @@ defmodule Hunter.ClientTest do
 
   describe "new/1" do
     test "builds a client with the given options" do
-      conn = Client.new(base_url: "https://example.com", bearer_token: "123456")
+      conn = Client.new(base_url: "https://example.com", access_token: "123456")
 
-      assert %Client{base_url: "https://example.com", bearer_token: "123456"} = conn
+      assert %Client{base_url: "https://example.com", access_token: "123456"} = conn
     end
   end
 

--- a/test/hunter/context_test.exs
+++ b/test/hunter/context_test.exs
@@ -5,7 +5,7 @@ defmodule Hunter.ContextTest do
 
   alias Hunter.Context
 
-  @conn Hunter.Client.new(base_url: "https://example.com", bearer_token: "123456")
+  @conn Hunter.Client.new(base_url: "https://example.com", access_token: "123456")
 
   setup :verify_on_exit!
 

--- a/test/hunter/domain_test.exs
+++ b/test/hunter/domain_test.exs
@@ -5,7 +5,7 @@ defmodule Hunter.DomainTest do
 
   alias Hunter.Domain
 
-  @conn Hunter.Client.new(base_url: "https://example.com", bearer_token: "123456")
+  @conn Hunter.Client.new(base_url: "https://example.com", access_token: "123456")
 
   setup :verify_on_exit!
 

--- a/test/hunter/instance_test.exs
+++ b/test/hunter/instance_test.exs
@@ -12,7 +12,7 @@ defmodule Hunter.InstanceTest do
       %Instance{uri: "social.lou.lt"}
     end)
 
-    conn = Hunter.Client.new(base_url: "https://example.com", bearer_token: "123456")
+    conn = Hunter.Client.new(base_url: "https://example.com", access_token: "123456")
     assert %Instance{uri: "social.lou.lt"} = Instance.instance_info(conn)
   end
 end

--- a/test/hunter/notification_test.exs
+++ b/test/hunter/notification_test.exs
@@ -5,7 +5,7 @@ defmodule Hunter.NotificationTest do
 
   alias Hunter.{Account, Notification}
 
-  @conn Hunter.Client.new(base_url: "https://example.com", bearer_token: "123456")
+  @conn Hunter.Client.new(base_url: "https://example.com", access_token: "123456")
 
   setup :verify_on_exit!
 

--- a/test/hunter/relationship_test.exs
+++ b/test/hunter/relationship_test.exs
@@ -5,7 +5,7 @@ defmodule Hunter.RelationshipTest do
 
   alias Hunter.Relationship
 
-  @conn Hunter.Client.new(base_url: "https://example.com", bearer_token: "123456")
+  @conn Hunter.Client.new(base_url: "https://example.com", access_token: "123456")
 
   setup :verify_on_exit!
 

--- a/test/hunter/report_test.exs
+++ b/test/hunter/report_test.exs
@@ -5,7 +5,7 @@ defmodule Hunter.ReportTest do
 
   alias Hunter.Report
 
-  @conn Hunter.Client.new(base_url: "https://example.com", bearer_token: "123456")
+  @conn Hunter.Client.new(base_url: "https://example.com", access_token: "123456")
 
   setup :verify_on_exit!
 

--- a/test/hunter/result_test.exs
+++ b/test/hunter/result_test.exs
@@ -5,7 +5,7 @@ defmodule Hunter.ResultTest do
 
   alias Hunter.Result
 
-  @conn Hunter.Client.new(base_url: "https://example.com", bearer_token: "123456")
+  @conn Hunter.Client.new(base_url: "https://example.com", access_token: "123456")
 
   setup :verify_on_exit!
 

--- a/test/hunter/status_test.exs
+++ b/test/hunter/status_test.exs
@@ -5,7 +5,7 @@ defmodule Hunter.StatusTest do
 
   alias Hunter.Status
 
-  @conn Hunter.Client.new(base_url: "https://example.com", bearer_token: "123456")
+  @conn Hunter.Client.new(base_url: "https://example.com", access_token: "123456")
 
   setup :verify_on_exit!
 

--- a/test/integration/mastodon_test.exs
+++ b/test/integration/mastodon_test.exs
@@ -127,4 +127,27 @@ defmodule Hunter.Integration.MastodonTest do
 
     Status.destroy_status(conn, id)
   end
+
+  test "README auth flow: create_app + log_in yields a token that can write", %{
+    conn: conn,
+    password2: password2
+  } do
+    app =
+      Hunter.create_app(
+        "hunter-auth-#{System.unique_integer([:positive])}",
+        "urn:ietf:wg:oauth:2.0:oob",
+        ["read", "write"],
+        nil,
+        api_base_url: conn.base_url
+      )
+
+    assert %Hunter.Application{scopes: ["read", "write"]} = app
+
+    logged_in = Hunter.log_in(app, "kadaba@example.com", password2, conn.base_url)
+    assert %Hunter.Client{access_token: token} = logged_in
+    assert is_binary(token)
+
+    %Status{id: id} = Status.create_status(logged_in, "auth flow works #hunterci")
+    Status.destroy_status(logged_in, id)
+  end
 end

--- a/test/support/integration_case.ex
+++ b/test/support/integration_case.ex
@@ -2,9 +2,10 @@ defmodule Hunter.IntegrationCase do
   @moduledoc """
   Case template for tests that run against a real Mastodon server.
 
-  Requires `HUNTER_BASE_URL`, `HUNTER_TOKEN` and `HUNTER_TOKEN2` to be set;
-  run via `mix test --only integration` so the mock-based unit suite does not
-  run concurrently (the API adapter is swapped globally).
+  Requires `HUNTER_BASE_URL`, `HUNTER_TOKEN`, `HUNTER_TOKEN2` and
+  `HUNTER_PASSWORD2` to be set; run via `mix test --only integration` so the
+  mock-based unit suite does not run concurrently (the API adapter is swapped
+  globally).
   """
 
   use ExUnit.CaseTemplate
@@ -22,6 +23,7 @@ defmodule Hunter.IntegrationCase do
     base_url = fetch_env!("HUNTER_BASE_URL")
     token = fetch_env!("HUNTER_TOKEN")
     token2 = fetch_env!("HUNTER_TOKEN2")
+    password2 = fetch_env!("HUNTER_PASSWORD2")
 
     previous_api = Application.get_env(:hunter, :hunter_api)
     previous_http = Application.get_env(:hunter, :http_options)
@@ -39,7 +41,8 @@ defmodule Hunter.IntegrationCase do
 
     {:ok,
      conn: Hunter.Client.new(base_url: base_url, access_token: token),
-     conn2: Hunter.Client.new(base_url: base_url, access_token: token2)}
+     conn2: Hunter.Client.new(base_url: base_url, access_token: token2),
+     password2: password2}
   end
 
   @doc """

--- a/test/support/integration_case.ex
+++ b/test/support/integration_case.ex
@@ -38,8 +38,8 @@ defmodule Hunter.IntegrationCase do
     end)
 
     {:ok,
-     conn: Hunter.Client.new(base_url: base_url, bearer_token: token),
-     conn2: Hunter.Client.new(base_url: base_url, bearer_token: token2)}
+     conn: Hunter.Client.new(base_url: base_url, access_token: token),
+     conn2: Hunter.Client.new(base_url: base_url, access_token: token2)}
   end
 
   @doc """


### PR DESCRIPTION
Fixes #100. Closes #101.

- `log_in/4` now sends the app's registered scopes in the password grant. Previously the `scope` parameter was omitted, so Doorkeeper granted Mastodon's default `read` scope and every write action failed with "This action is outside the authorized scopes" — reproduced and verified live against Mastodon v4.3.8. `Hunter.Application` records the requested scopes (persisted by `save?: true`); stale credential files (`scopes: nil`) keep the old behavior until `create_app` is re-run.
- BREAKING: `Hunter.Client.bearer_token` → `access_token` (#101), aligned with other Mastodon client libraries.
- New live integration test covers the README auth flow end to end (create_app → log_in → post → delete), using a known password minted by the setup script (`HUNTER_PASSWORD2`).
- Restores the #74 changelog entry dropped in the #109 rebase-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)