### PR TITLE
Send Authorization on domain block/unblock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@
       scope, making every write action fail with "This action is outside the
       authorized scopes" ([#100]). Re-run `create_app` once to refresh saved
       credentials created by older hunter versions.
+    - `block_domain/2` and `unblock_domain/2` now send the `Authorization`
+      header; previously they always failed with "The access token is
+      invalid" ([#110])
 
 ## v0.5.1
 
@@ -96,3 +99,4 @@
 [#74]: https://github.com/milmazz/hunter/issues/74
 [#100]: https://github.com/milmazz/hunter/issues/100
 [#101]: https://github.com/milmazz/hunter/issues/101
+[#110]: https://github.com/milmazz/hunter/issues/110

--- a/lib/hunter/api/http_client.ex
+++ b/lib/hunter/api/http_client.ex
@@ -344,13 +344,13 @@ defmodule Hunter.Api.HTTPClient do
   def block_domain(conn, domain) do
     "/api/v1/domain_blocks"
     |> process_url(conn)
-    |> request!(nil, :post, %{domain: domain})
+    |> request!(nil, :post, %{domain: domain}, conn)
   end
 
   def unblock_domain(conn, domain) do
     "/api/v1/domain_blocks"
     |> process_url(conn)
-    |> request!(nil, :delete, %{domain: domain})
+    |> request!(nil, :delete, %{domain: domain}, conn)
   end
 
   ## Helpers

--- a/test/integration/mastodon_test.exs
+++ b/test/integration/mastodon_test.exs
@@ -1,7 +1,7 @@
 defmodule Hunter.Integration.MastodonTest do
   use Hunter.IntegrationCase, async: false
 
-  alias Hunter.{Account, Attachment, Instance, Notification, Relationship, Result, Status}
+  alias Hunter.{Account, Attachment, Domain, Instance, Notification, Relationship, Result, Status}
 
   @png Base.decode64!(
          "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
@@ -149,5 +149,13 @@ defmodule Hunter.Integration.MastodonTest do
 
     %Status{id: id} = Status.create_status(logged_in, "auth flow works #hunterci")
     Status.destroy_status(logged_in, id)
+  end
+
+  test "blocks and unblocks a domain", %{conn: conn} do
+    assert Domain.block_domain(conn, "blocked.example")
+    assert "blocked.example" in Domain.blocked_domains(conn)
+
+    assert Domain.unblock_domain(conn, "blocked.example")
+    refute "blocked.example" in Domain.blocked_domains(conn)
   end
 end


### PR DESCRIPTION
Fixes #110.

`block_domain/2` and `unblock_domain/2` called `request!/4` without `conn`, so no `Authorization` header was ever sent — both could only return "The access token is invalid" against a real server. Root cause verified live (reproduced before the fix, green after), fixed by passing `conn` exactly as every sibling endpoint does, and covered by a new live integration test for the block → list → unblock flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)