### PR TITLE
Send redirect_uri in the OAuth token exchange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@
     - `block_domain/2` and `unblock_domain/2` now send the `Authorization`
       header; previously they always failed with "The access token is
       invalid" ([#110])
+    - `Hunter.log_in_oauth/3` now sends the `redirect_uri` in the token
+      exchange; Doorkeeper rejects the authorization-code grant without it,
+      so the function could never succeed. `Hunter.Application` records the
+      redirect URI the app was registered with; stale saved credentials fall
+      back to `urn:ietf:wg:oauth:2.0:oob` ([#112])
 
 ## v0.5.1
 
@@ -100,3 +105,4 @@
 [#100]: https://github.com/milmazz/hunter/issues/100
 [#101]: https://github.com/milmazz/hunter/issues/101
 [#110]: https://github.com/milmazz/hunter/issues/110
+[#112]: https://github.com/milmazz/hunter/issues/112

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,9 +53,12 @@ Below are the guidelines for working on Pull Requests:
 
   Requires Docker. The stack is disposable: `docker compose -f docker-compose.ci.yml down -v`.
   You can also point the suite at any instance you own by exporting
-  `HUNTER_BASE_URL`, `HUNTER_TOKEN`, `HUNTER_TOKEN2` and `HUNTER_PASSWORD2`
-  (the account password for the second user, used by the auth-flow test)
-  yourself.
+  `HUNTER_BASE_URL`, `HUNTER_TOKEN`, `HUNTER_TOKEN2`, `HUNTER_PASSWORD2`
+  (the account password for the second user, used by the auth-flow test),
+  and `HUNTER_OAUTH_CLIENT_ID`/`HUNTER_OAUTH_CLIENT_SECRET`/`HUNTER_OAUTH_CODE`
+  (an app and a fresh authorization code for the OAuth-flow test) yourself.
+  Authorization codes are single-use: re-run `scripts/ci/setup_mastodon.sh`
+  (or mint a new code) before re-running the suite.
 
 ## New features or bug fixes
 

--- a/lib/hunter/api/http_client.ex
+++ b/lib/hunter/api/http_client.ex
@@ -81,7 +81,7 @@ defmodule Hunter.Api.HTTPClient do
       |> process_url(base_url)
       |> request!(:application, :post, payload)
 
-    %Hunter.Application{app | scopes: scopes}
+    %Hunter.Application{app | scopes: scopes, redirect_uri: redirect_uri}
   end
 
   def upload_media(conn, file, options) do
@@ -315,16 +315,15 @@ defmodule Hunter.Api.HTTPClient do
     %Hunter.Client{base_url: base_url, access_token: response["access_token"]}
   end
 
-  def log_in_oauth(
-        %Hunter.Application{client_id: client_id, client_secret: client_secret},
-        oauth_code,
-        base_url
-      ) do
+  def log_in_oauth(%Hunter.Application{} = app, oauth_code, base_url) do
     payload = %{
-      client_id: client_id,
-      client_secret: client_secret,
+      client_id: app.client_id,
+      client_secret: app.client_secret,
       grant_type: "authorization_code",
-      code: oauth_code
+      code: oauth_code,
+      # Doorkeeper rejects the exchange without a redirect_uri matching the
+      # authorization; fall back to create_app's default for stale credentials
+      redirect_uri: app.redirect_uri || "urn:ietf:wg:oauth:2.0:oob"
     }
 
     response =

--- a/lib/hunter/application.ex
+++ b/lib/hunter/application.ex
@@ -11,6 +11,7 @@ defmodule Hunter.Application do
     * `client_id` - client id
     * `client_secret` - client secret
     * `scopes` - scopes requested when the app was registered
+    * `redirect_uri` - redirect URI the app was registered with
 
   """
   alias Hunter.Config
@@ -19,11 +20,12 @@ defmodule Hunter.Application do
           id: non_neg_integer,
           client_id: String.t(),
           client_secret: String.t(),
-          scopes: [String.t()] | nil
+          scopes: [String.t()] | nil,
+          redirect_uri: String.t() | nil
         }
 
   @derive [Poison.Encoder]
-  defstruct [:id, :client_id, :client_secret, :scopes]
+  defstruct [:id, :client_id, :client_secret, :scopes, :redirect_uri]
 
   @doc """
   Register a new OAuth client app on the target instance

--- a/scripts/ci/setup_mastodon.sh
+++ b/scripts/ci/setup_mastodon.sh
@@ -92,11 +92,33 @@ TOKEN2=$(mint_token kadaba)
 PASSWORD2=$($COMPOSE exec -T web bin/tootctl accounts modify kadaba --reset-password \
   | awk '/New password:/ {print $3}')
 
+# A fresh authorization grant per provisioning run: authorization codes are
+# single-use, so the oauth integration test consumes this one code per run.
+OAUTH_PROVISION=$($COMPOSE exec -T web bin/rails runner "
+  app = Doorkeeper::Application.find_or_create_by!(name: 'hunter-ci-oauth') do |a|
+    a.redirect_uri = 'urn:ietf:wg:oauth:2.0:oob'
+    a.scopes = 'read write'
+  end
+  user = User.find_by!(email: 'kadaba@example.com')
+  grant = Doorkeeper::AccessGrant.create!(
+    application_id: app.id, resource_owner_id: user.id,
+    redirect_uri: app.redirect_uri, expires_in: 86_400, scopes: app.scopes.to_s
+  )
+  code = (grant.respond_to?(:plaintext_token) && grant.plaintext_token) || grant.token
+  puts [app.uid, app.secret, code].join(' ')
+" | tr -d '\r')
+read -r OAUTH_CLIENT_ID OAUTH_CLIENT_SECRET OAUTH_CODE <<EOF2
+$OAUTH_PROVISION
+EOF2
+
 cat > "$HUNTER_ENV" <<EOF
 export HUNTER_BASE_URL=https://localhost:3000
 export HUNTER_TOKEN=$TOKEN1
 export HUNTER_TOKEN2=$TOKEN2
 export HUNTER_PASSWORD2=$PASSWORD2
+export HUNTER_OAUTH_CLIENT_ID=$OAUTH_CLIENT_ID
+export HUNTER_OAUTH_CLIENT_SECRET=$OAUTH_CLIENT_SECRET
+export HUNTER_OAUTH_CODE=$OAUTH_CODE
 EOF
 
 if [ -n "${GITHUB_ENV:-}" ]; then
@@ -105,6 +127,9 @@ if [ -n "${GITHUB_ENV:-}" ]; then
     echo "HUNTER_TOKEN=$TOKEN1"
     echo "HUNTER_TOKEN2=$TOKEN2"
     echo "HUNTER_PASSWORD2=$PASSWORD2"
+    echo "HUNTER_OAUTH_CLIENT_ID=$OAUTH_CLIENT_ID"
+    echo "HUNTER_OAUTH_CLIENT_SECRET=$OAUTH_CLIENT_SECRET"
+    echo "HUNTER_OAUTH_CODE=$OAUTH_CODE"
   } >> "$GITHUB_ENV"
 fi
 

--- a/test/hunter/application_test.exs
+++ b/test/hunter/application_test.exs
@@ -27,7 +27,8 @@ defmodule Hunter.ApplicationTest do
         client_id: "1234567890",
         client_secret: "1234567890",
         id: 1234,
-        scopes: ["read"]
+        scopes: ["read"],
+        redirect_uri: "urn:ietf:wg:oauth:2.0:oob"
       }
     end)
 
@@ -51,7 +52,9 @@ defmodule Hunter.ApplicationTest do
                api_base_url: "https://example.com"
              )
 
-    assert %Hunter.Application{scopes: ["read"]} = Hunter.Application.load_credentials(app_name)
+    assert %Hunter.Application{scopes: ["read"], redirect_uri: "urn:ietf:wg:oauth:2.0:oob"} =
+             Hunter.Application.load_credentials(app_name)
+
     Application.put_env(:hunter, :home, home)
   end
 
@@ -66,14 +69,18 @@ defmodule Hunter.ApplicationTest do
       id: 1234,
       client_secret: "1234567890",
       client_id: "1234567890",
-      scopes: ["read", "write"]
+      scopes: ["read", "write"],
+      redirect_uri: "urn:ietf:wg:oauth:2.0:oob"
     }
 
     unless File.exists?(app_dir), do: File.mkdir_p!(app_dir)
 
     File.write!("#{app_dir}/#{app_name}.json", Poison.encode!(expected))
 
-    assert %Hunter.Application{scopes: ["read", "write"]} =
+    assert %Hunter.Application{
+             scopes: ["read", "write"],
+             redirect_uri: "urn:ietf:wg:oauth:2.0:oob"
+           } =
              app = Hunter.Application.load_credentials(app_name)
 
     assert Map.equal?(Map.from_struct(app), expected)

--- a/test/integration/mastodon_test.exs
+++ b/test/integration/mastodon_test.exs
@@ -158,4 +158,25 @@ defmodule Hunter.Integration.MastodonTest do
     assert Domain.unblock_domain(conn, "blocked.example")
     refute "blocked.example" in Domain.blocked_domains(conn)
   end
+
+  test "OAuth authorization-code flow: log_in_oauth yields a working client", %{
+    conn: conn,
+    oauth_client_id: client_id,
+    oauth_client_secret: client_secret,
+    oauth_code: code
+  } do
+    app = %Hunter.Application{
+      client_id: client_id,
+      client_secret: client_secret,
+      scopes: ["read", "write"],
+      redirect_uri: "urn:ietf:wg:oauth:2.0:oob"
+    }
+
+    logged_in = Hunter.log_in_oauth(app, code, conn.base_url)
+    assert %Hunter.Client{access_token: token} = logged_in
+    assert is_binary(token)
+
+    %Status{id: id} = Status.create_status(logged_in, "oauth flow works #hunterci")
+    Status.destroy_status(logged_in, id)
+  end
 end

--- a/test/support/integration_case.ex
+++ b/test/support/integration_case.ex
@@ -2,10 +2,12 @@ defmodule Hunter.IntegrationCase do
   @moduledoc """
   Case template for tests that run against a real Mastodon server.
 
-  Requires `HUNTER_BASE_URL`, `HUNTER_TOKEN`, `HUNTER_TOKEN2` and
-  `HUNTER_PASSWORD2` to be set; run via `mix test --only integration` so the
-  mock-based unit suite does not run concurrently (the API adapter is swapped
-  globally).
+  Requires `HUNTER_BASE_URL`, `HUNTER_TOKEN`, `HUNTER_TOKEN2`,
+  `HUNTER_PASSWORD2`, `HUNTER_OAUTH_CLIENT_ID`, `HUNTER_OAUTH_CLIENT_SECRET`
+  and `HUNTER_OAUTH_CODE` to be set; run via `mix test --only integration` so
+  the mock-based unit suite does not run concurrently (the API adapter is
+  swapped globally). The OAuth authorization code is single-use — re-run
+  `scripts/ci/setup_mastodon.sh` before re-running the suite.
   """
 
   use ExUnit.CaseTemplate
@@ -24,6 +26,9 @@ defmodule Hunter.IntegrationCase do
     token = fetch_env!("HUNTER_TOKEN")
     token2 = fetch_env!("HUNTER_TOKEN2")
     password2 = fetch_env!("HUNTER_PASSWORD2")
+    oauth_client_id = fetch_env!("HUNTER_OAUTH_CLIENT_ID")
+    oauth_client_secret = fetch_env!("HUNTER_OAUTH_CLIENT_SECRET")
+    oauth_code = fetch_env!("HUNTER_OAUTH_CODE")
 
     previous_api = Application.get_env(:hunter, :hunter_api)
     previous_http = Application.get_env(:hunter, :http_options)
@@ -42,7 +47,10 @@ defmodule Hunter.IntegrationCase do
     {:ok,
      conn: Hunter.Client.new(base_url: base_url, access_token: token),
      conn2: Hunter.Client.new(base_url: base_url, access_token: token2),
-     password2: password2}
+     password2: password2,
+     oauth_client_id: oauth_client_id,
+     oauth_client_secret: oauth_client_secret,
+     oauth_code: oauth_code}
   end
 
   @doc """


### PR DESCRIPTION
Fixes #112.

`log_in_oauth/3` omitted `redirect_uri` from the token exchange; Doorkeeper requires it for the authorization_code grant, so the function could never succeed against a real server — verified live (`invalid_request: Missing required parameter: redirect_uri.` without it; token granted with it).

- `Hunter.Application` records the redirect URI the app was registered with (same pattern as the scopes fix in #111, persisted by `save?: true`); stale credentials fall back to `urn:ietf:wg:oauth:2.0:oob`
- `setup_mastodon.sh` mints a fresh authorization grant per provisioning run (`HUNTER_OAUTH_*` env vars); a new live integration test exchanges it via `log_in_oauth` and posts a status with the resulting client
- Authorization codes are single-use — CONTRIBUTING documents re-running the setup script before re-running the suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)