### PR TITLE
Test-suite follow-ups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@
       so the function could never succeed. `Hunter.Application` records the
       redirect URI the app was registered with; stale saved credentials fall
       back to `urn:ietf:wg:oauth:2.0:oob` ([#112])
+    - Account `emojis` now decode as `Hunter.Emoji` structs, matching the
+      documented typespec; previously they were plain maps ([#107])
 
 ## v0.5.1
 
@@ -106,3 +108,4 @@
 [#101]: https://github.com/milmazz/hunter/issues/101
 [#110]: https://github.com/milmazz/hunter/issues/110
 [#112]: https://github.com/milmazz/hunter/issues/112
+[#107]: https://github.com/milmazz/hunter/issues/107

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -45,6 +45,11 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "ps aux | grep '[s]idekiq' || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
 
   nginx:
     image: nginx:1.27-alpine

--- a/docs/superpowers/specs/2026-07-06-ci-and-test-suite-design.md
+++ b/docs/superpowers/specs/2026-07-06-ci-and-test-suite-design.md
@@ -123,3 +123,19 @@ Three layers, ordered by value:
 - Coverage reporting (declined during design).
 - Streaming API (`Hunter.EventStream`) integration tests — websocket/SSE
   testing is a follow-up.
+
+## Errata (post-implementation)
+
+Recorded after the stack merged; the sections above are the point-in-time
+design and are intentionally left as written.
+
+- The matrix floor shipped as **Elixir 1.15 / OTP 26**, not OTP 25: the
+  updated dependency lock (`quic 1.7.0`, via hackney) does not compile on
+  OTP 25. Exercised the spec's own escape hatch; recorded in CHANGELOG and
+  PR #102.
+- The integration env contract grew beyond `HUNTER_BASE_URL`/`HUNTER_TOKEN`:
+  the suite also requires `HUNTER_TOKEN2` (second account, follow/notification
+  tests), and later `HUNTER_PASSWORD2` (password-grant auth-flow test, #100)
+  and `HUNTER_OAUTH_CLIENT_ID`/`HUNTER_OAUTH_CLIENT_SECRET`/`HUNTER_OAUTH_CODE`
+  (OAuth flow test, #112). `scripts/ci/setup_mastodon.sh` provisions all of
+  them; see CONTRIBUTING.md for the current list.

--- a/lib/hunter/api/transformer.ex
+++ b/lib/hunter/api/transformer.ex
@@ -3,9 +3,9 @@ defmodule Hunter.Api.Transformer do
   Decodes Mastodon API JSON payloads into Hunter entity structs.
   """
 
-  def transform(body, :account), do: Poison.decode!(body, as: %Hunter.Account{})
+  def transform(body, :account), do: Poison.decode!(body, as: account_nested_struct())
 
-  def transform(body, :accounts), do: Poison.decode!(body, as: [%Hunter.Account{}])
+  def transform(body, :accounts), do: Poison.decode!(body, as: [account_nested_struct()])
 
   def transform(body, :application), do: Poison.decode!(body, as: %Hunter.Application{})
 
@@ -44,7 +44,7 @@ defmodule Hunter.Api.Transformer do
     Poison.decode!(
       body,
       as: %Hunter.Result{
-        accounts: [%Hunter.Account{}],
+        accounts: [account_nested_struct()],
         statuses: [status_nested_struct()],
         hashtags: [%Hunter.Tag{}]
       }
@@ -53,9 +53,13 @@ defmodule Hunter.Api.Transformer do
 
   def transform(body, _), do: Poison.decode!(body)
 
+  defp account_nested_struct do
+    %Hunter.Account{emojis: [%Hunter.Emoji{}]}
+  end
+
   defp status_nested_struct do
     %Hunter.Status{
-      account: %Hunter.Account{},
+      account: account_nested_struct(),
       reblog: %Hunter.Status{},
       media_attachments: [%Hunter.Attachment{}],
       mentions: [%Hunter.Mention{}],
@@ -66,7 +70,7 @@ defmodule Hunter.Api.Transformer do
 
   defp notification_nested_struct do
     %Hunter.Notification{
-      account: %Hunter.Account{},
+      account: account_nested_struct(),
       status: status_nested_struct()
     }
   end

--- a/scripts/ci/setup_mastodon.sh
+++ b/scripts/ci/setup_mastodon.sh
@@ -72,13 +72,14 @@ create_user() {
 create_user hunter
 create_user kadaba
 
+# The email travels via env var (ENV.fetch), never interpolated into Ruby.
 mint_token() {
-  $COMPOSE exec -T web bin/rails runner "
+  $COMPOSE exec -T -e MINT_EMAIL="$1@example.com" web bin/rails runner "
     app = Doorkeeper::Application.find_or_create_by!(name: 'hunter-ci') do |a|
       a.redirect_uri = 'urn:ietf:wg:oauth:2.0:oob'
       a.scopes = 'read write follow'
     end
-    user = User.find_by!(email: '$1@example.com')
+    user = User.find_by!(email: ENV.fetch('MINT_EMAIL'))
     token = Doorkeeper::AccessToken.find_or_create_by!(
       application_id: app.id, resource_owner_id: user.id, revoked_at: nil
     ) { |t| t.scopes = app.scopes.to_s }

--- a/test/fixtures/account.json
+++ b/test/fixtures/account.json
@@ -13,5 +13,13 @@
   "avatar": "https://mastodon.example/avatars/original/missing.png",
   "avatar_static": "https://mastodon.example/avatars/original/missing.png",
   "header": "https://mastodon.example/headers/original/missing.png",
-  "header_static": "https://mastodon.example/headers/original/missing.png"
+  "header_static": "https://mastodon.example/headers/original/missing.png",
+  "emojis": [
+    {
+      "shortcode": "blobcat",
+      "url": "https://mastodon.example/emojis/blobcat.png",
+      "static_url": "https://mastodon.example/emojis/blobcat_static.png",
+      "visible_in_picker": true
+    }
+  ]
 }

--- a/test/hunter/api/transformer_test.exs
+++ b/test/hunter/api/transformer_test.exs
@@ -12,6 +12,8 @@ defmodule Hunter.Api.TransformerTest do
     assert account.display_name == "Milton Mazzarri"
     assert account.followers_count == 118
     assert account.url == "https://mastodon.example/@milmazz"
+
+    assert [%Hunter.Emoji{shortcode: "blobcat", visible_in_picker: true}] = account.emojis
   end
 
   test "decodes a list of accounts" do

--- a/test/hunter/integration_case_test.exs
+++ b/test/hunter/integration_case_test.exs
@@ -1,0 +1,20 @@
+defmodule Hunter.IntegrationCaseTest do
+  use ExUnit.Case, async: true
+
+  @tag timeout: 2_000
+  test "eventually/2 with attempts <= 1 runs the function exactly once" do
+    {:ok, agent} = Agent.start_link(fn -> 0 end)
+
+    assert_raise RuntimeError, "nope", fn ->
+      Hunter.IntegrationCase.eventually(
+        fn ->
+          Agent.update(agent, &(&1 + 1))
+          raise "nope"
+        end,
+        0
+      )
+    end
+
+    assert Agent.get(agent, & &1) == 1
+  end
+end

--- a/test/integration/mastodon_test.exs
+++ b/test/integration/mastodon_test.exs
@@ -26,6 +26,7 @@ defmodule Hunter.Integration.MastodonTest do
 
     status = Status.create_status(conn, text)
     assert %Status{id: id, content: content} = status
+    on_exit(fn -> destroy_quietly(conn, id) end)
     assert content =~ "hunterci"
 
     assert %Status{id: ^id} = Status.status(conn, id)
@@ -44,6 +45,7 @@ defmodule Hunter.Integration.MastodonTest do
 
   test "statuses appear on the local public timeline", %{conn: conn} do
     %Status{id: id} = Status.create_status(conn, "timeline check #hunterci")
+    on_exit(fn -> destroy_quietly(conn, id) end)
 
     eventually(fn ->
       timeline = Status.public_timeline(conn, local: true)
@@ -58,9 +60,11 @@ defmodule Hunter.Integration.MastodonTest do
     %Account{id: id2} = Account.verify_credentials(conn2)
 
     assert %Relationship{following: true} = Relationship.follow(conn, id2)
+    on_exit(fn -> unfollow_quietly(conn, id2) end)
     assert [%Relationship{following: true}] = Relationship.relationships(conn, [id2])
 
     %Status{id: status_id} = Status.create_status(conn2, "hello @hunter #hunterci")
+    on_exit(fn -> destroy_quietly(conn2, status_id) end)
 
     eventually(fn ->
       notifications = Notification.notifications(conn)
@@ -92,6 +96,7 @@ defmodule Hunter.Integration.MastodonTest do
         Status.create_status(conn, "media test #hunterci", media_ids: [media_id])
       end)
 
+    on_exit(fn -> destroy_quietly(conn, id) end)
     assert Enum.any?(attachments, &(&1.id == media_id))
     Status.destroy_status(conn, id)
   end
@@ -101,6 +106,8 @@ defmodule Hunter.Integration.MastodonTest do
 
     %Status{id: id1} = Status.create_status(conn, "pagination one #hunterci")
     %Status{id: id2} = Status.create_status(conn, "pagination two #hunterci")
+    on_exit(fn -> destroy_quietly(conn, id1) end)
+    on_exit(fn -> destroy_quietly(conn, id2) end)
 
     eventually(fn ->
       assert [%Status{}] = Status.statuses(conn, account_id, limit: 1)
@@ -116,6 +123,7 @@ defmodule Hunter.Integration.MastodonTest do
 
   test "searches via /api/v2/search returning v2 shapes", %{conn: conn} do
     %Status{id: id} = Status.create_status(conn, "tagged search probe #hunterci")
+    on_exit(fn -> destroy_quietly(conn, id) end)
 
     eventually(fn ->
       result = Result.search(conn, "hunterci")
@@ -148,11 +156,13 @@ defmodule Hunter.Integration.MastodonTest do
     assert is_binary(token)
 
     %Status{id: id} = Status.create_status(logged_in, "auth flow works #hunterci")
+    on_exit(fn -> destroy_quietly(logged_in, id) end)
     Status.destroy_status(logged_in, id)
   end
 
   test "blocks and unblocks a domain", %{conn: conn} do
     assert Domain.block_domain(conn, "blocked.example")
+    on_exit(fn -> unblock_quietly(conn, "blocked.example") end)
     assert "blocked.example" in Domain.blocked_domains(conn)
 
     assert Domain.unblock_domain(conn, "blocked.example")
@@ -177,6 +187,30 @@ defmodule Hunter.Integration.MastodonTest do
     assert is_binary(token)
 
     %Status{id: id} = Status.create_status(logged_in, "oauth flow works #hunterci")
+    on_exit(fn -> destroy_quietly(logged_in, id) end)
     Status.destroy_status(logged_in, id)
+  end
+
+  # Failure-path cleanup: on_exit nets that tolerate state already removed by
+  # the test body's own assertions.
+  defp destroy_quietly(conn, id) do
+    Status.destroy_status(conn, id)
+    :ok
+  rescue
+    Hunter.Error -> :ok
+  end
+
+  defp unfollow_quietly(conn, id) do
+    Relationship.unfollow(conn, id)
+    :ok
+  rescue
+    Hunter.Error -> :ok
+  end
+
+  defp unblock_quietly(conn, domain) do
+    Domain.unblock_domain(conn, domain)
+    :ok
+  rescue
+    Hunter.Error -> :ok
   end
 end

--- a/test/support/integration_case.ex
+++ b/test/support/integration_case.ex
@@ -59,7 +59,7 @@ defmodule Hunter.IntegrationCase do
   """
   def eventually(fun, attempts \\ 30)
 
-  def eventually(fun, 1), do: fun.()
+  def eventually(fun, attempts) when attempts <= 1, do: fun.()
 
   def eventually(fun, attempts) do
     fun.()


### PR DESCRIPTION
Closes #107 — all six deferred items from the whole-branch review:

- Account `emojis` decode as `Hunter.Emoji` structs (fixture + transformer test; behavior now matches the documented typespec)
- `eventually/2` guards against non-positive attempts (was an infinite loop; unit-tested)
- Integration tests register `on_exit` cleanup nets for every piece of server state they create (statuses, follow, domain block), so failures no longer leak on non-ephemeral servers
- `mint_token` passes the email to `rails runner` via `ENV.fetch` instead of shell-into-Ruby interpolation
- sidekiq service has a process-liveness healthcheck (verified `(healthy)` on a fresh boot)
- The 2026-07-06 design spec gained an Errata section recording the OTP-26 floor and the grown env-var contract

Verified: fresh provisioning run, 12/12 live integration, 77 unit tests + 4 doctests, format/credo/dialyzer clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)