### PR TITLE
Prepare the project for the 0.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,30 @@
 
 ## Unreleased
 
+  * Features
+    - `Hunter.log_in_oauth/3`: obtain an access token from an OAuth
+      authorization code (the authorization-code grant), complementing the
+      existing password-grant `Hunter.log_in/4`
+    - `Hunter.Application` now records the `scopes` and `redirect_uri` the
+      app was registered with (persisted by `save?: true`), so the login
+      helpers can request them
+
   * Breaking changes
     - Require Elixir 1.15+ and Erlang/OTP 26+ (transitive dependencies of
       httpoison 3.0 no longer compile on OTP 25)
+    - Major dependency upgrades: httpoison 1.x → 3.0 and poison 4.x/5.x →
+      6.0; check for version conflicts with sibling dependencies in your tree
     - `Hunter.Result.hashtags` is now a list of `Hunter.Tag` structs (the
       `/api/v2/search` shape) instead of strings.
-    - Removed `Hunter.follow_by_uri/2` / `Hunter.Account.follow_by_uri/2`:
+    - Removed the `follow_by_uri` function (`Hunter` and `Hunter.Account`):
       Mastodon 4.0 removed `POST /api/v1/follows`. Search for the account and
       use `Hunter.follow/2` instead.
-    - Removed `Hunter.reports/1` / `Hunter.Report.reports/1`: Mastodon removed
-      `GET /api/v1/reports`. Filing reports via `Hunter.report/4` still works.
+    - Removed the `reports` listing function (`Hunter` and `Hunter.Report`):
+      Mastodon removed `GET /api/v1/reports`. Filing reports via
+      `Hunter.report/4` still works.
+    - The `Hunter.Api` behaviour contract changed: `log_in_oauth/3` is a new
+      required callback, and the `follow_by_uri`/`reports` callbacks were
+      removed — custom API adapters need updating
     - `Hunter.Client` field `bearer_token` was renamed to `access_token` for
       consistency with other Mastodon client libraries; update
       `Hunter.Client.new(bearer_token: …)` calls to `access_token:` ([#101])

--- a/README.md
+++ b/README.md
@@ -1,16 +1,15 @@
 # Hunter
 
 [![Hex.pm](https://img.shields.io/hexpm/v/hunter.svg?style=flat-square)](https://hex.pm/packages/hunter)
-[![Ebert](https://ebertapp.io/github/milmazz/hunter.svg)](https://ebertapp.io/github/milmazz/hunter)
-[![Build Status](https://travis-ci.org/milmazz/hunter.svg?branch=master)](https://travis-ci.org/milmazz/hunter)
+[![CI](https://github.com/milmazz/hunter/actions/workflows/ci.yml/badge.svg)](https://github.com/milmazz/hunter/actions/workflows/ci.yml)
 
-A Elixir client for [Mastodon](https://github.com/Gargron/mastodon/), a GNU social-compatible micro-blogging service
+An Elixir client for the [Mastodon](https://joinmastodon.org/) API
 
 ## Installation
 
 ```elixir
 def deps do
-  [{:hunter, "~> 0.4"}]
+  [{:hunter, "~> 0.6"}]
 end
 ```
 
@@ -418,10 +417,12 @@ If you want to provide another API adapter, you can change the following option:
 config :hunter, hunter_api: Hunter.Api.HTTPClient
 ```
 
-For example, to run local tests we use the following adapter:
+Any module implementing the `Hunter.Api` behaviour works here. For example,
+hunter's own unit tests swap in a [Mox](https://hex.pm/packages/mox) mock:
 
 ```elixir
-config :hunter, hunter_api: Hunter.Api.InMemory
+Mox.defmock(Hunter.ApiMock, for: Hunter.Api)
+Application.put_env(:hunter, :hunter_api, Hunter.ApiMock)
 ```
 
 Finally, you can also change the default API base url (`https://mastodon.social`):
@@ -432,6 +433,7 @@ config :hunter, api_base_url: "https://mastodon.social"
 
 ## License
 
-Hunter source code is released under Apache 2 License.
+Hunter source code is released under the Apache License 2.0.
 
-Check the [LICENSE](LICENSE) for more information.
+Check the [LICENSE](https://github.com/milmazz/hunter/blob/main/LICENSE) file
+for more information.

--- a/lib/hunter.ex
+++ b/lib/hunter.ex
@@ -1,6 +1,6 @@
 defmodule Hunter do
   @moduledoc """
-  An Elixir client for Mastodon, a GNU Social compatible micro-blogging service
+  An Elixir client for the Mastodon API
   """
 
   @hunter_version Mix.Project.config()[:version]

--- a/lib/hunter/api/transformer.ex
+++ b/lib/hunter/api/transformer.ex
@@ -1,7 +1,6 @@
 defmodule Hunter.Api.Transformer do
-  @moduledoc """
-  Decodes Mastodon API JSON payloads into Hunter entity structs.
-  """
+  # Decodes Mastodon API JSON payloads into Hunter entity structs.
+  @moduledoc false
 
   def transform(body, :account), do: Poison.decode!(body, as: account_nested_struct())
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,15 +1,18 @@
 defmodule Hunter.Mixfile do
   use Mix.Project
 
+  @version "0.6.0-dev"
+  @source_url "https://github.com/milmazz/hunter"
+
   def project do
     [
       app: :hunter,
-      version: "0.6.0-dev",
+      version: @version,
       elixir: "~> 1.15",
       docs: docs(),
       package: package(),
-      source_url: "https://github.com/milmazz/hunter",
-      description: "Elixir client for Mastodon, a GNU social-compatible micro-blogging service",
+      source_url: @source_url,
+      description: "Elixir client for the Mastodon API",
       start_permanent: Mix.env() == :prod,
       elixirc_paths: elixirc_paths(Mix.env()),
       deps: deps(),
@@ -45,9 +48,10 @@ defmodule Hunter.Mixfile do
 
   defp package do
     [
-      licenses: ["Apache 2.0"],
+      files: ~w(lib .formatter.exs mix.exs README.md LICENSE CHANGELOG.md),
+      licenses: ["Apache-2.0"],
       maintainers: ["Milton Mazzarri"],
-      links: %{"GitHub" => "https://github.com/milmazz/hunter"}
+      links: %{"GitHub" => @source_url}
     ]
   end
 
@@ -59,7 +63,8 @@ defmodule Hunter.Mixfile do
         "CODE_OF_CONDUCT.md": [title: "Code of Conduct"],
         "CHANGELOG.md": [title: "Changelog"]
       ],
-      main: "readme"
+      main: "readme",
+      source_ref: "v#{@version}"
     ]
   end
 end


### PR DESCRIPTION
Pre-release fixes from the project review. **The release cut itself (version bump, changelog date, tag, publish) is deliberately NOT in this PR** — after this merges, main is ready for the mechanical cut.

- **Hex package**: explicit `files:` list — previously `mix hex.build` packed the 4.3 MB dialyzer PLT from `priv/plts/` into the tarball; SPDX license id (`Apache-2.0`); package description modernized (it's the hex.pm page text)
- **README**: GitHub Actions badge (Travis and Ebert are dead services), install pin `~> 0.6`, the adapter example now shows Mox instead of the removed `Hunter.Api.InMemory`, wording refresh
- **CHANGELOG**: `log_in_oauth/3` and the new `Application.scopes`/`redirect_uri` fields recorded as Features (they're new API since 0.5.1, not just bug-fix context); the `Hunter.Api` behaviour-contract changes (new + removed callbacks — affects custom adapters) and the httpoison/poison major bumps recorded as Breaking
- **Docs**: `source_ref` derived from the version so hexdocs source links target the release tag; `Hunter.Api.Transformer` marked internal; `mix docs` warnings 10 → 0

Deferred with an issue: #116 (id typespecs say `non_neg_integer`, Mastodon returns strings — spec-only fix batched for the #103 window).

🤖 Generated with [Claude Code](https://claude.com/claude-code)