### PR TITLE
Release 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.6.0
 
   * Features
     - `Hunter.log_in_oauth/3`: obtain an access token from an OAuth

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Hunter.Mixfile do
   use Mix.Project
 
-  @version "0.6.0-dev"
+  @version "0.6.0"
   @source_url "https://github.com/milmazz/hunter"
 
   def project do


### PR DESCRIPTION
The mechanical cut: `@version` → `"0.6.0"` (docs `source_ref` follows automatically) and the CHANGELOG `## Unreleased` section retitled `## v0.6.0`, matching the file's existing header style.

Verified: full gate green; `mix hex.build` produces `hunter-0.6.0.tar` with the clean file list; `mix docs` builds with zero warnings.

After merging:

```
git checkout main && git pull
git tag v0.6.0 && git push origin v0.6.0
mix hex.publish
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)