### PR TITLE
Modernize entity structs to Mastodon 4.6 shapes

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -1,0 +1,16 @@
+# Overrides Credo's defaults; every check not listed here keeps its
+# default configuration.
+%{
+  configs: [
+    %{
+      name: "default",
+      checks: %{
+        extra: [
+          # Entity structs mirror the upstream Mastodon API entities, whose
+          # field counts we don't control (Status has 33 attributes)
+          {Credo.Check.Warning.StructFieldAmount, max_fields: 40}
+        ]
+      }
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,46 @@
 # Changelog
 
+## Unreleased
+
+  * Features
+    - Modernized the existing entity structs to the Mastodon 4.6 shapes
+      ([#119]):
+      - `Hunter.Status`: `text`, `edited_at`, `replies_count`, `bookmarked`,
+        `pinned`, `emojis`, `poll`, `filtered`, `quote`, `quote_approval`
+      - `Hunter.Account`: `uri`, `last_status_at`, `group`, `discoverable`,
+        `noindex`, `suspended`, `limited`, `hide_collections`, `roles`,
+        `attribution_domains`, `source`; `fields` is now a list of
+        `Hunter.Field` structs
+      - `Hunter.Relationship`: `showing_reblogs`, `notifying`, `languages`,
+        `blocked_by`, `muting_notifications`, `muting_expires_at`,
+        `requested_by`, `endorsed`, `note`
+      - `Hunter.Notification`: `group_key`, `report`, `event`,
+        `moderation_warning`
+      - `Hunter.Tag`: `id`, `history`, `following`, `featuring`
+      - `Hunter.Card`: `blurhash`, `embed_url`, `authors` (list of
+        `Hunter.Card.Author`), plus `published_at`/`history` for trending
+        links
+      - `Hunter.Attachment`: `blurhash`, `preview_remote_url`
+      - `Hunter.Emoji`: `category`
+      - `Hunter.Application`: `name`, `website`, `redirect_uris`,
+        `client_secret_expires_at` (the `CredentialApplication` shape)
+      - `Hunter.Instance.rules` is now a list of `Hunter.Rule` structs
+    - New entity structs, ready for the endpoints that return them ([#119]):
+      `Hunter.Poll` (and `Hunter.Poll.Option`), `Hunter.Quote`,
+      `Hunter.Filter`, `Hunter.FilterKeyword`, `Hunter.FilterStatus`,
+      `Hunter.FilterResult`, `Hunter.Translation`, `Hunter.ScheduledStatus`,
+      `Hunter.List`, `Hunter.Conversation`, `Hunter.Marker`,
+      `Hunter.Suggestion`, `Hunter.FeaturedTag`, `Hunter.Announcement` (and
+      `Hunter.Announcement.Reaction`), `Hunter.Preferences`, `Hunter.Field`,
+      `Hunter.Role`, `Hunter.NotificationPolicy`,
+      `Hunter.NotificationRequest`, `Hunter.NotificationGroup`,
+      `Hunter.WebPushSubscription`, `Hunter.Rule`,
+      `Hunter.ExtendedDescription`, `Hunter.PrivacyPolicy`,
+      `Hunter.TermsOfService`, `Hunter.DomainBlock`, `Hunter.Collection`
+      (and `Hunter.Collection.Item`), `Hunter.AnnualReport`
+
+[#119]: https://github.com/milmazz/hunter/issues/119
+
 ## v0.6.0
 
   * Features

--- a/lib/hunter/account.ex
+++ b/lib/hunter/account.ex
@@ -24,7 +24,22 @@ defmodule Hunter.Account do
     * `header_static` - URL to the header static image (gif)
     * `emojis` - list of emojis
     * `moved` - moved from account
+    * `fields` - list of `Hunter.Field`, additional profile metadata
     * `bot` - whether this account is a bot or not
+    * `group` - whether this account represents a group actor
+    * `discoverable` - whether the account has opted into discovery features
+    * `noindex` - whether the local user has opted out of search engine indexing
+    * `suspended` - whether the account has been suspended (returns with
+      limited profile data when true)
+    * `limited` - whether the account has been silenced
+    * `last_status_at` - date (not time) of the account's last status, if any
+    * `hide_collections` - whether the user hides their followers/following collections
+    * `uri` - the ActivityPub actor URI of the account
+    * `roles` - list of `Hunter.Role` with a visible badge
+    * `attribution_domains` - domains allowed to credit the account in link previews
+    * `source` - profile source data as entered by the user (plain-text `note`,
+      default `privacy`, etc.), only returned by `verify_credentials` and
+      `update_credentials`
 
   """
   alias Hunter.Config
@@ -36,19 +51,30 @@ defmodule Hunter.Account do
           display_name: String.t(),
           note: String.t(),
           url: String.t(),
+          uri: String.t(),
           avatar: String.t(),
           avatar_static: String.t(),
           header: String.t(),
           header_static: String.t(),
           locked: String.t(),
           created_at: String.t(),
+          last_status_at: String.t() | nil,
           followers_count: non_neg_integer,
           following_count: non_neg_integer,
           statuses_count: non_neg_integer,
           emojis: [Hunter.Emoji.t()],
           moved: t(),
-          fields: [any()],
-          bot: boolean
+          fields: [Hunter.Field.t()],
+          bot: boolean,
+          group: boolean,
+          discoverable: boolean | nil,
+          noindex: boolean | nil,
+          suspended: boolean | nil,
+          limited: boolean | nil,
+          hide_collections: boolean | nil,
+          roles: [Hunter.Role.t()],
+          attribution_domains: [String.t()],
+          source: map | nil
         }
 
   @derive [Poison.Encoder]
@@ -59,19 +85,30 @@ defmodule Hunter.Account do
     :display_name,
     :note,
     :url,
+    :uri,
     :avatar,
     :avatar_static,
     :header,
     :header_static,
     :locked,
     :created_at,
+    :last_status_at,
     :followers_count,
     :following_count,
     :statuses_count,
     :emojis,
     :moved,
     :fields,
-    :bot
+    :bot,
+    :group,
+    :discoverable,
+    :noindex,
+    :suspended,
+    :limited,
+    :hide_collections,
+    :roles,
+    :attribution_domains,
+    :source
   ]
 
   @doc """

--- a/lib/hunter/announcement.ex
+++ b/lib/hunter/announcement.ex
@@ -60,35 +60,4 @@ defmodule Hunter.Announcement do
     :emojis,
     :reactions
   ]
-
-  defmodule Reaction do
-    @moduledoc """
-    Announcement reaction entity
-
-    An emoji reaction attached to a `Hunter.Announcement`
-
-    ## Fields
-
-      * `name` - the emoji used for the reaction, either a unicode emoji or
-        a custom emoji's shortcode
-      * `count` - the total number of users who have added this reaction
-      * `me` - whether the authenticated user added this reaction (only with
-        user token)
-      * `url` - URL of the custom emoji, if the reaction is a custom emoji
-      * `static_url` - static URL of the custom emoji, if the reaction is a
-        custom emoji
-
-    """
-
-    @type t :: %__MODULE__{
-            name: String.t(),
-            count: non_neg_integer,
-            me: boolean | nil,
-            url: String.t() | nil,
-            static_url: String.t() | nil
-          }
-
-    @derive [Poison.Encoder]
-    defstruct [:name, :count, :me, :url, :static_url]
-  end
 end

--- a/lib/hunter/announcement.ex
+++ b/lib/hunter/announcement.ex
@@ -1,0 +1,94 @@
+defmodule Hunter.Announcement do
+  @moduledoc """
+  Announcement entity
+
+  An announcement set by an administrator
+
+  ## Fields
+
+    * `id` - the ID of the announcement
+    * `content` - the text of the announcement, as HTML
+    * `starts_at` - when the announcement starts being active, if time-limited
+    * `ends_at` - when the announcement stops being active, if time-limited
+    * `all_day` - whether the announcement should start and end on dates only
+      instead of datetimes
+    * `published_at` - when the announcement was published
+    * `updated_at` - when the announcement was last updated
+    * `read` - whether the announcement has been read by the authenticated
+      user (only with user token)
+    * `mentions` - accounts mentioned in the announcement text, list of maps
+      with `id`, `username`, `url` and `acct` keys
+    * `statuses` - statuses linked in the announcement text, list of maps
+      with `id` and `url` keys
+    * `tags` - list of `Hunter.Tag` used in the announcement text
+    * `emojis` - list of `Hunter.Emoji`, custom emoji used in the
+      announcement text
+    * `reactions` - list of `Hunter.Announcement.Reaction`, emoji reactions
+      attached to the announcement
+
+  """
+
+  @type t :: %__MODULE__{
+          id: String.t(),
+          content: String.t(),
+          starts_at: String.t() | nil,
+          ends_at: String.t() | nil,
+          all_day: boolean,
+          published_at: String.t(),
+          updated_at: String.t(),
+          read: boolean | nil,
+          mentions: [map],
+          statuses: [map],
+          tags: [Hunter.Tag.t()],
+          emojis: [Hunter.Emoji.t()],
+          reactions: [Hunter.Announcement.Reaction.t()]
+        }
+
+  @derive [Poison.Encoder]
+  defstruct [
+    :id,
+    :content,
+    :starts_at,
+    :ends_at,
+    :all_day,
+    :published_at,
+    :updated_at,
+    :read,
+    :mentions,
+    :statuses,
+    :tags,
+    :emojis,
+    :reactions
+  ]
+
+  defmodule Reaction do
+    @moduledoc """
+    Announcement reaction entity
+
+    An emoji reaction attached to a `Hunter.Announcement`
+
+    ## Fields
+
+      * `name` - the emoji used for the reaction, either a unicode emoji or
+        a custom emoji's shortcode
+      * `count` - the total number of users who have added this reaction
+      * `me` - whether the authenticated user added this reaction (only with
+        user token)
+      * `url` - URL of the custom emoji, if the reaction is a custom emoji
+      * `static_url` - static URL of the custom emoji, if the reaction is a
+        custom emoji
+
+    """
+
+    @type t :: %__MODULE__{
+            name: String.t(),
+            count: non_neg_integer,
+            me: boolean | nil,
+            url: String.t() | nil,
+            static_url: String.t() | nil
+          }
+
+    @derive [Poison.Encoder]
+    defstruct [:name, :count, :me, :url, :static_url]
+  end
+end

--- a/lib/hunter/announcement/reaction.ex
+++ b/lib/hunter/announcement/reaction.ex
@@ -1,0 +1,30 @@
+defmodule Hunter.Announcement.Reaction do
+  @moduledoc """
+  Announcement reaction entity
+
+  An emoji reaction attached to a `Hunter.Announcement`
+
+  ## Fields
+
+    * `name` - the emoji used for the reaction, either a unicode emoji or
+      a custom emoji's shortcode
+    * `count` - the total number of users who have added this reaction
+    * `me` - whether the authenticated user added this reaction (only with
+      user token)
+    * `url` - URL of the custom emoji, if the reaction is a custom emoji
+    * `static_url` - static URL of the custom emoji, if the reaction is a
+      custom emoji
+
+  """
+
+  @type t :: %__MODULE__{
+          name: String.t(),
+          count: non_neg_integer,
+          me: boolean | nil,
+          url: String.t() | nil,
+          static_url: String.t() | nil
+        }
+
+  @derive [Poison.Encoder]
+  defstruct [:name, :count, :me, :url, :static_url]
+end

--- a/lib/hunter/annual_report.ex
+++ b/lib/hunter/annual_report.ex
@@ -1,0 +1,28 @@
+defmodule Hunter.AnnualReport do
+  @moduledoc """
+  AnnualReport entity
+
+  A yearly summary of account activity ("Wrapstodon")
+
+  ## Fields
+
+    * `year` - the year this report is about
+    * `data` - the raw report data as a map; its shape depends on
+      `schema_version`
+    * `schema_version` - which schema version defines how to interpret `data`
+    * `share_url` - a link to a shareable version of the report, if any
+    * `account_id` - the ID of the account this report is about
+
+  """
+
+  @type t :: %__MODULE__{
+          year: non_neg_integer,
+          data: map,
+          schema_version: non_neg_integer,
+          share_url: String.t() | nil,
+          account_id: String.t()
+        }
+
+  @derive [Poison.Encoder]
+  defstruct [:year, :data, :schema_version, :share_url, :account_id]
+end

--- a/lib/hunter/api/transformer.ex
+++ b/lib/hunter/api/transformer.ex
@@ -20,7 +20,8 @@ defmodule Hunter.Api.Transformer do
     )
   end
 
-  def transform(body, :instance), do: Poison.decode!(body, as: %Hunter.Instance{})
+  def transform(body, :instance),
+    do: Poison.decode!(body, as: %Hunter.Instance{rules: [%Hunter.Rule{}]})
 
   def transform(body, :notification), do: Poison.decode!(body, as: notification_nested_struct())
 
@@ -30,6 +31,100 @@ defmodule Hunter.Api.Transformer do
   def transform(body, :status), do: Poison.decode!(body, as: status_nested_struct())
 
   def transform(body, :statuses), do: Poison.decode!(body, as: [status_nested_struct()])
+
+  def transform(body, :notification_policy),
+    do: Poison.decode!(body, as: %Hunter.NotificationPolicy{})
+
+  def transform(body, :notification_request),
+    do: Poison.decode!(body, as: notification_request_nested_struct())
+
+  def transform(body, :notification_requests),
+    do: Poison.decode!(body, as: [notification_request_nested_struct()])
+
+  def transform(body, :notification_group),
+    do: Poison.decode!(body, as: notification_group_nested_struct())
+
+  def transform(body, :notification_groups),
+    do: Poison.decode!(body, as: [notification_group_nested_struct()])
+
+  def transform(body, :web_push_subscription),
+    do: Poison.decode!(body, as: %Hunter.WebPushSubscription{})
+
+  def transform(body, :rule), do: Poison.decode!(body, as: %Hunter.Rule{})
+
+  def transform(body, :rules), do: Poison.decode!(body, as: [%Hunter.Rule{}])
+
+  def transform(body, :extended_description),
+    do: Poison.decode!(body, as: %Hunter.ExtendedDescription{})
+
+  def transform(body, :privacy_policy), do: Poison.decode!(body, as: %Hunter.PrivacyPolicy{})
+
+  def transform(body, :terms_of_service), do: Poison.decode!(body, as: %Hunter.TermsOfService{})
+
+  def transform(body, :domain_block), do: Poison.decode!(body, as: %Hunter.DomainBlock{})
+
+  def transform(body, :domain_blocks), do: Poison.decode!(body, as: [%Hunter.DomainBlock{}])
+
+  def transform(body, :collection), do: Poison.decode!(body, as: collection_nested_struct())
+
+  def transform(body, :collections), do: Poison.decode!(body, as: [collection_nested_struct()])
+
+  def transform(body, :annual_report), do: Poison.decode!(body, as: %Hunter.AnnualReport{})
+
+  def transform(body, :annual_reports), do: Poison.decode!(body, as: [%Hunter.AnnualReport{}])
+
+  def transform(body, :list), do: Poison.decode!(body, as: %Hunter.List{})
+
+  def transform(body, :lists), do: Poison.decode!(body, as: [%Hunter.List{}])
+
+  def transform(body, :conversation), do: Poison.decode!(body, as: conversation_nested_struct())
+
+  def transform(body, :conversations),
+    do: Poison.decode!(body, as: [conversation_nested_struct()])
+
+  def transform(body, :markers) do
+    Poison.decode!(
+      body,
+      as: %{"home" => %Hunter.Marker{}, "notifications" => %Hunter.Marker{}}
+    )
+  end
+
+  def transform(body, :suggestion), do: Poison.decode!(body, as: suggestion_nested_struct())
+
+  def transform(body, :suggestions), do: Poison.decode!(body, as: [suggestion_nested_struct()])
+
+  def transform(body, :featured_tag), do: Poison.decode!(body, as: %Hunter.FeaturedTag{})
+
+  def transform(body, :featured_tags), do: Poison.decode!(body, as: [%Hunter.FeaturedTag{}])
+
+  def transform(body, :announcement), do: Poison.decode!(body, as: announcement_nested_struct())
+
+  def transform(body, :announcements),
+    do: Poison.decode!(body, as: [announcement_nested_struct()])
+
+  def transform(body, :preferences), do: Poison.decode!(body, as: %Hunter.Preferences{})
+
+  def transform(body, :poll), do: Poison.decode!(body, as: poll_nested_struct())
+
+  def transform(body, :filter), do: Poison.decode!(body, as: filter_nested_struct())
+
+  def transform(body, :filters), do: Poison.decode!(body, as: [filter_nested_struct()])
+
+  def transform(body, :filter_keyword), do: Poison.decode!(body, as: %Hunter.FilterKeyword{})
+
+  def transform(body, :filter_keywords), do: Poison.decode!(body, as: [%Hunter.FilterKeyword{}])
+
+  def transform(body, :filter_status), do: Poison.decode!(body, as: %Hunter.FilterStatus{})
+
+  def transform(body, :filter_statuses), do: Poison.decode!(body, as: [%Hunter.FilterStatus{}])
+
+  def transform(body, :translation), do: Poison.decode!(body, as: %Hunter.Translation{})
+
+  def transform(body, :scheduled_status),
+    do: Poison.decode!(body, as: scheduled_status_nested_struct())
+
+  def transform(body, :scheduled_statuses),
+    do: Poison.decode!(body, as: [scheduled_status_nested_struct()])
 
   def transform(body, :relationship), do: Poison.decode!(body, as: %Hunter.Relationship{})
 
@@ -51,7 +146,11 @@ defmodule Hunter.Api.Transformer do
   def transform(body, _), do: Poison.decode!(body)
 
   defp account_nested_struct do
-    %Hunter.Account{emojis: [%Hunter.Emoji{}]}
+    %Hunter.Account{
+      emojis: [%Hunter.Emoji{}],
+      fields: [%Hunter.Field{}],
+      roles: [%Hunter.Role{}]
+    }
   end
 
   defp status_nested_struct do
@@ -61,15 +160,70 @@ defmodule Hunter.Api.Transformer do
       media_attachments: [%Hunter.Attachment{}],
       mentions: [%Hunter.Mention{}],
       tags: [%Hunter.Tag{}],
+      emojis: [%Hunter.Emoji{}],
       application: %Hunter.Application{},
-      card: %Hunter.Card{}
+      card: card_nested_struct(),
+      poll: poll_nested_struct(),
+      filtered: [%Hunter.FilterResult{filter: filter_nested_struct()}],
+      quote: %Hunter.Quote{quoted_status: %Hunter.Status{account: account_nested_struct()}}
     }
+  end
+
+  defp poll_nested_struct do
+    %Hunter.Poll{options: [%Hunter.Poll.Option{}], emojis: [%Hunter.Emoji{}]}
+  end
+
+  defp filter_nested_struct do
+    %Hunter.Filter{keywords: [%Hunter.FilterKeyword{}], statuses: [%Hunter.FilterStatus{}]}
+  end
+
+  defp scheduled_status_nested_struct do
+    %Hunter.ScheduledStatus{media_attachments: [%Hunter.Attachment{}]}
+  end
+
+  defp conversation_nested_struct do
+    %Hunter.Conversation{
+      accounts: [account_nested_struct()],
+      last_status: status_nested_struct()
+    }
+  end
+
+  defp suggestion_nested_struct do
+    %Hunter.Suggestion{account: account_nested_struct()}
+  end
+
+  defp announcement_nested_struct do
+    %Hunter.Announcement{
+      tags: [%Hunter.Tag{}],
+      emojis: [%Hunter.Emoji{}],
+      reactions: [%Hunter.Announcement.Reaction{}]
+    }
+  end
+
+  defp notification_request_nested_struct do
+    %Hunter.NotificationRequest{
+      account: account_nested_struct(),
+      last_status: status_nested_struct()
+    }
+  end
+
+  defp notification_group_nested_struct do
+    %Hunter.NotificationGroup{report: %Hunter.Report{}}
+  end
+
+  defp collection_nested_struct do
+    %Hunter.Collection{items: [%Hunter.Collection.Item{}]}
+  end
+
+  defp card_nested_struct do
+    %Hunter.Card{authors: [%Hunter.Card.Author{account: account_nested_struct()}]}
   end
 
   defp notification_nested_struct do
     %Hunter.Notification{
       account: account_nested_struct(),
-      status: status_nested_struct()
+      status: status_nested_struct(),
+      report: %Hunter.Report{}
     }
   end
 end

--- a/lib/hunter/application.ex
+++ b/lib/hunter/application.ex
@@ -5,27 +5,51 @@ defmodule Hunter.Application do
   This module defines a `Hunter.Application` struct and the main functions
   for working with Applications.
 
+  The struct covers both the `Application` entity embedded in statuses
+  (`name` and `website` only) and the `CredentialApplication` entity returned
+  when registering an app (which adds the client credentials).
+
   ## Fields
 
     * `id` -  identifier
+    * `name` - the name of the application
+    * `website` - the website associated with the application, if any
     * `client_id` - client id
     * `client_secret` - client secret
+    * `client_secret_expires_at` - when the client secret expires, currently
+      always `0` (never expires)
     * `scopes` - scopes requested when the app was registered
-    * `redirect_uri` - redirect URI the app was registered with
+    * `redirect_uris` - redirect URIs the app was registered with
+    * `redirect_uri` - redirect URI the app was registered with (deprecated
+      since Mastodon 4.3 in favor of `redirect_uris`)
 
   """
   alias Hunter.Config
 
   @type t :: %__MODULE__{
           id: non_neg_integer,
+          name: String.t() | nil,
+          website: String.t() | nil,
           client_id: String.t(),
           client_secret: String.t(),
+          client_secret_expires_at: non_neg_integer | nil,
           scopes: [String.t()] | nil,
+          redirect_uris: [String.t()] | nil,
           redirect_uri: String.t() | nil
         }
 
   @derive [Poison.Encoder]
-  defstruct [:id, :client_id, :client_secret, :scopes, :redirect_uri]
+  defstruct [
+    :id,
+    :name,
+    :website,
+    :client_id,
+    :client_secret,
+    :client_secret_expires_at,
+    :scopes,
+    :redirect_uris,
+    :redirect_uri
+  ]
 
   @doc """
   Register a new OAuth client app on the target instance

--- a/lib/hunter/attachment.ex
+++ b/lib/hunter/attachment.ex
@@ -8,7 +8,7 @@ defmodule Hunter.Attachment do
   ## Fields
 
     * `id` - ID of the attachment
-    * `type` - One of: "image", "video", "gifv", "unknown"
+    * `type` - One of: "image", "video", "gifv", "audio", "unknown"
     * `url` - URL of the locally hosted version of the image
     * `remote_url` - For remote images, the remote URL of the original image
     * `preview_url` - URL of the preview image
@@ -17,7 +17,10 @@ defmodule Hunter.Attachment do
     * `meta` - May contain subtress `small` and `original`. Images may contain:
       `width`, `height`, `size`, `aspect`, while videos (including `gifv`) may
       contain: `width`, `height`, `frame_rate`, `duration`, and `bitrate`.
+    * `preview_remote_url` - for remote images, the remote URL of the preview image
     * `description` - attachment description
+    * `blurhash` - hash computed by the BlurHash algorithm, for generating
+      colorful preview thumbnails when media has not been downloaded yet
 
   **Note**: When the type is "unknown", it is likely only `remote_url` is
   available and local `url` is missing
@@ -31,13 +34,26 @@ defmodule Hunter.Attachment do
           url: String.t(),
           remote_url: String.t(),
           preview_url: String.t(),
+          preview_remote_url: String.t() | nil,
           text_url: String.t(),
-          meta: String.t(),
-          description: String.t()
+          meta: map | nil,
+          description: String.t(),
+          blurhash: String.t() | nil
         }
 
   @derive [Poison.Encoder]
-  defstruct [:id, :type, :url, :remote_url, :preview_url, :text_url, :meta, :description]
+  defstruct [
+    :id,
+    :type,
+    :url,
+    :remote_url,
+    :preview_url,
+    :preview_remote_url,
+    :text_url,
+    :meta,
+    :description,
+    :blurhash
+  ]
 
   @doc """
   Upload a media attachment

--- a/lib/hunter/card.ex
+++ b/lib/hunter/card.ex
@@ -19,6 +19,13 @@ defmodule Hunter.Card do
     * `html` - HTML required to display the resource
     * `width` - width in pixels
     * `height` - height in pixels
+    * `blurhash` - hash computed by the BlurHash algorithm, for generating
+      colorful preview thumbnails when media has not been downloaded yet
+    * `embed_url` - used for photo embeds instead of custom `html`
+    * `authors` - list of `Hunter.Card.Author`, fediverse authors of the resource
+    * `published_at` - publication date as a UNIX timestamp, only present on
+      trending links
+    * `history` - usage statistics, only present on trending links
 
   """
 
@@ -34,7 +41,12 @@ defmodule Hunter.Card do
           provider_url: String.t(),
           html: String.t(),
           width: non_neg_integer,
-          height: non_neg_integer
+          height: non_neg_integer,
+          blurhash: String.t() | nil,
+          embed_url: String.t() | nil,
+          authors: [Hunter.Card.Author.t()] | nil,
+          published_at: String.t() | nil,
+          history: [map] | nil
         }
 
   @derive [Poison.Encoder]
@@ -50,6 +62,35 @@ defmodule Hunter.Card do
     :provider_url,
     :html,
     :width,
-    :height
+    :height,
+    :blurhash,
+    :embed_url,
+    :authors,
+    :published_at,
+    :history
   ]
+
+  defmodule Author do
+    @moduledoc """
+    Card author entity
+
+    A fediverse author of the resource a `Hunter.Card` previews
+
+    ## Fields
+
+      * `name` - the original resource author's name
+      * `url` - a link to the author's website
+      * `account` - the author's `Hunter.Account`, if known to the instance
+
+    """
+
+    @type t :: %__MODULE__{
+            name: String.t(),
+            url: String.t(),
+            account: Hunter.Account.t() | nil
+          }
+
+    @derive [Poison.Encoder]
+    defstruct [:name, :url, :account]
+  end
 end

--- a/lib/hunter/card.ex
+++ b/lib/hunter/card.ex
@@ -69,28 +69,4 @@ defmodule Hunter.Card do
     :published_at,
     :history
   ]
-
-  defmodule Author do
-    @moduledoc """
-    Card author entity
-
-    A fediverse author of the resource a `Hunter.Card` previews
-
-    ## Fields
-
-      * `name` - the original resource author's name
-      * `url` - a link to the author's website
-      * `account` - the author's `Hunter.Account`, if known to the instance
-
-    """
-
-    @type t :: %__MODULE__{
-            name: String.t(),
-            url: String.t(),
-            account: Hunter.Account.t() | nil
-          }
-
-    @derive [Poison.Encoder]
-    defstruct [:name, :url, :account]
-  end
 end

--- a/lib/hunter/card/author.ex
+++ b/lib/hunter/card/author.ex
@@ -1,0 +1,23 @@
+defmodule Hunter.Card.Author do
+  @moduledoc """
+  Card author entity
+
+  A fediverse author of the resource a `Hunter.Card` previews
+
+  ## Fields
+
+    * `name` - the original resource author's name
+    * `url` - a link to the author's website
+    * `account` - the author's `Hunter.Account`, if known to the instance
+
+  """
+
+  @type t :: %__MODULE__{
+          name: String.t(),
+          url: String.t(),
+          account: Hunter.Account.t() | nil
+        }
+
+  @derive [Poison.Encoder]
+  defstruct [:name, :url, :account]
+end

--- a/lib/hunter/collection.ex
+++ b/lib/hunter/collection.ex
@@ -1,0 +1,91 @@
+defmodule Hunter.Collection do
+  @moduledoc """
+  Collection entity
+
+  A curated collection of accounts
+
+  ## Fields
+
+    * `id` - the ID of the collection
+    * `account_id` - the ID of the account that created the collection
+    * `uri` - the ActivityPub URI of the collection
+    * `url` - a web URL for the collection, if any
+    * `name` - the name of the collection
+    * `description` - HTML description of the collection
+    * `language` - the language of the collection, if set
+    * `local` - whether the collection originates from this instance
+    * `sensitive` - whether the collection is marked as sensitive
+    * `discoverable` - whether the collection has opted into discovery
+      features
+    * `tag` - the tag associated with the collection, if any
+    * `created_at` - when the collection was created
+    * `updated_at` - when the collection was last updated
+    * `item_count` - number of items in the collection
+    * `items` - list of `Hunter.Collection.Item`
+
+  """
+
+  @type t :: %__MODULE__{
+          id: String.t(),
+          account_id: String.t(),
+          uri: String.t(),
+          url: String.t() | nil,
+          name: String.t(),
+          description: String.t(),
+          language: String.t() | nil,
+          local: boolean,
+          sensitive: boolean,
+          discoverable: boolean,
+          tag: map | nil,
+          created_at: String.t(),
+          updated_at: String.t(),
+          item_count: non_neg_integer,
+          items: [Hunter.Collection.Item.t()]
+        }
+
+  @derive [Poison.Encoder]
+  defstruct [
+    :id,
+    :account_id,
+    :uri,
+    :url,
+    :name,
+    :description,
+    :language,
+    :local,
+    :sensitive,
+    :discoverable,
+    :tag,
+    :created_at,
+    :updated_at,
+    :item_count,
+    :items
+  ]
+
+  defmodule Item do
+    @moduledoc """
+    Collection item entity
+
+    An account featured in a `Hunter.Collection`
+
+    ## Fields
+
+      * `id` - the ID of the collection item
+      * `account_id` - the ID of the account this item represents
+      * `state` - consent state of the item, one of: `pending`, `accepted`,
+        `rejected`, `revoked`
+      * `created_at` - when the item was added to the collection
+
+    """
+
+    @type t :: %__MODULE__{
+            id: String.t(),
+            account_id: String.t() | nil,
+            state: String.t(),
+            created_at: String.t()
+          }
+
+    @derive [Poison.Encoder]
+    defstruct [:id, :account_id, :state, :created_at]
+  end
+end

--- a/lib/hunter/collection.ex
+++ b/lib/hunter/collection.ex
@@ -61,31 +61,4 @@ defmodule Hunter.Collection do
     :item_count,
     :items
   ]
-
-  defmodule Item do
-    @moduledoc """
-    Collection item entity
-
-    An account featured in a `Hunter.Collection`
-
-    ## Fields
-
-      * `id` - the ID of the collection item
-      * `account_id` - the ID of the account this item represents
-      * `state` - consent state of the item, one of: `pending`, `accepted`,
-        `rejected`, `revoked`
-      * `created_at` - when the item was added to the collection
-
-    """
-
-    @type t :: %__MODULE__{
-            id: String.t(),
-            account_id: String.t() | nil,
-            state: String.t(),
-            created_at: String.t()
-          }
-
-    @derive [Poison.Encoder]
-    defstruct [:id, :account_id, :state, :created_at]
-  end
 end

--- a/lib/hunter/collection/item.ex
+++ b/lib/hunter/collection/item.ex
@@ -1,0 +1,26 @@
+defmodule Hunter.Collection.Item do
+  @moduledoc """
+  Collection item entity
+
+  An account featured in a `Hunter.Collection`
+
+  ## Fields
+
+    * `id` - the ID of the collection item
+    * `account_id` - the ID of the account this item represents
+    * `state` - consent state of the item, one of: `pending`, `accepted`,
+      `rejected`, `revoked`
+    * `created_at` - when the item was added to the collection
+
+  """
+
+  @type t :: %__MODULE__{
+          id: String.t(),
+          account_id: String.t() | nil,
+          state: String.t(),
+          created_at: String.t()
+        }
+
+  @derive [Poison.Encoder]
+  defstruct [:id, :account_id, :state, :created_at]
+end

--- a/lib/hunter/conversation.ex
+++ b/lib/hunter/conversation.ex
@@ -1,0 +1,25 @@
+defmodule Hunter.Conversation do
+  @moduledoc """
+  Conversation entity
+
+  A conversation with "direct message" visibility
+
+  ## Fields
+
+    * `id` - the ID of the conversation
+    * `unread` - whether the conversation is currently marked as unread
+    * `accounts` - list of `Hunter.Account`, participants in the conversation
+    * `last_status` - the last `Hunter.Status` in the conversation, if any
+
+  """
+
+  @type t :: %__MODULE__{
+          id: String.t(),
+          unread: boolean,
+          accounts: [Hunter.Account.t()],
+          last_status: Hunter.Status.t() | nil
+        }
+
+  @derive [Poison.Encoder]
+  defstruct [:id, :unread, :accounts, :last_status]
+end

--- a/lib/hunter/domain_block.ex
+++ b/lib/hunter/domain_block.ex
@@ -1,0 +1,28 @@
+defmodule Hunter.DomainBlock do
+  @moduledoc """
+  DomainBlock entity
+
+  A domain that is blocked by the instance, as returned by the instance
+  domain blocks endpoint
+
+  ## Fields
+
+    * `domain` - the domain which is blocked; may be obfuscated or partially
+      censored
+    * `digest` - the SHA256 hash digest of the domain string
+    * `severity` - the level to which the domain is blocked, one of:
+      `silence`, `suspend`
+    * `comment` - an optional reason for the domain block
+
+  """
+
+  @type t :: %__MODULE__{
+          domain: String.t(),
+          digest: String.t(),
+          severity: String.t(),
+          comment: String.t() | nil
+        }
+
+  @derive [Poison.Encoder]
+  defstruct [:domain, :digest, :severity, :comment]
+end

--- a/lib/hunter/emoji.ex
+++ b/lib/hunter/emoji.ex
@@ -6,9 +6,10 @@ defmodule Hunter.Emoji do
           shortcode: String.t(),
           static_url: String.t(),
           url: String.t(),
-          visible_in_picker: boolean()
+          visible_in_picker: boolean(),
+          category: String.t() | nil
         }
 
   @derive [Poison.Encoder]
-  defstruct [:shortcode, :static_url, :url, :visible_in_picker]
+  defstruct [:shortcode, :static_url, :url, :visible_in_picker, :category]
 end

--- a/lib/hunter/extended_description.ex
+++ b/lib/hunter/extended_description.ex
@@ -1,0 +1,21 @@
+defmodule Hunter.ExtendedDescription do
+  @moduledoc """
+  ExtendedDescription entity
+
+  An extended description of the instance, to be shown on its about page
+
+  ## Fields
+
+    * `updated_at` - when the content was last updated
+    * `content` - the rendered HTML content of the extended description
+
+  """
+
+  @type t :: %__MODULE__{
+          updated_at: String.t(),
+          content: String.t()
+        }
+
+  @derive [Poison.Encoder]
+  defstruct [:updated_at, :content]
+end

--- a/lib/hunter/featured_tag.ex
+++ b/lib/hunter/featured_tag.ex
@@ -1,0 +1,28 @@
+defmodule Hunter.FeaturedTag do
+  @moduledoc """
+  FeaturedTag entity
+
+  A hashtag that is featured on a profile
+
+  ## Fields
+
+    * `id` - the ID of the featured tag
+    * `name` - the name of the hashtag being featured, without the `#`
+    * `url` - link to all statuses by the user that contain the hashtag
+    * `statuses_count` - number of authored statuses containing the hashtag
+    * `last_status_at` - date of the last authored status containing the
+      hashtag, if any
+
+  """
+
+  @type t :: %__MODULE__{
+          id: String.t(),
+          name: String.t(),
+          url: String.t(),
+          statuses_count: non_neg_integer,
+          last_status_at: String.t() | nil
+        }
+
+  @derive [Poison.Encoder]
+  defstruct [:id, :name, :url, :statuses_count, :last_status_at]
+end

--- a/lib/hunter/field.ex
+++ b/lib/hunter/field.ex
@@ -1,0 +1,25 @@
+defmodule Hunter.Field do
+  @moduledoc """
+  Field entity
+
+  A profile field as a name-value pair with optional verification, part of
+  `Hunter.Account`
+
+  ## Fields
+
+    * `name` - the key of a given field's key-value pair
+    * `value` - the value associated with the `name` key; this will contain HTML
+    * `verified_at` - timestamp of when the server verified a URL value for a
+      rel="me" link, `nil` if not verified
+
+  """
+
+  @type t :: %__MODULE__{
+          name: String.t(),
+          value: String.t(),
+          verified_at: String.t() | nil
+        }
+
+  @derive [Poison.Encoder]
+  defstruct [:name, :value, :verified_at]
+end

--- a/lib/hunter/filter.ex
+++ b/lib/hunter/filter.ex
@@ -1,0 +1,36 @@
+defmodule Hunter.Filter do
+  @moduledoc """
+  Filter entity
+
+  A server-side filter group (v2 filters)
+
+  ## Fields
+
+    * `id` - the ID of the filter
+    * `title` - the title given by the user to the filter
+    * `context` - contexts in which the filter is applied, list of:
+      `home`, `notifications`, `public`, `thread`, `account`
+    * `expires_at` - when the filter should no longer be applied, `nil` when
+      it never expires
+    * `filter_action` - action to take when a status matches the filter, one
+      of: `warn`, `hide`, `blur`
+    * `keywords` - list of `Hunter.FilterKeyword`, the keywords grouped under
+      this filter
+    * `statuses` - list of `Hunter.FilterStatus`, the statuses grouped under
+      this filter
+
+  """
+
+  @type t :: %__MODULE__{
+          id: String.t(),
+          title: String.t(),
+          context: [String.t()],
+          expires_at: String.t() | nil,
+          filter_action: String.t(),
+          keywords: [Hunter.FilterKeyword.t()],
+          statuses: [Hunter.FilterStatus.t()]
+        }
+
+  @derive [Poison.Encoder]
+  defstruct [:id, :title, :context, :expires_at, :filter_action, :keywords, :statuses]
+end

--- a/lib/hunter/filter_keyword.ex
+++ b/lib/hunter/filter_keyword.ex
@@ -1,0 +1,24 @@
+defmodule Hunter.FilterKeyword do
+  @moduledoc """
+  FilterKeyword entity
+
+  A keyword that, if matched, should cause the filter action to be taken,
+  part of `Hunter.Filter`
+
+  ## Fields
+
+    * `id` - the ID of the filter keyword
+    * `keyword` - the phrase to be matched against
+    * `whole_word` - whether the keyword should consider word boundaries
+
+  """
+
+  @type t :: %__MODULE__{
+          id: String.t(),
+          keyword: String.t(),
+          whole_word: boolean
+        }
+
+  @derive [Poison.Encoder]
+  defstruct [:id, :keyword, :whole_word]
+end

--- a/lib/hunter/filter_result.ex
+++ b/lib/hunter/filter_result.ex
@@ -1,0 +1,25 @@
+defmodule Hunter.FilterResult do
+  @moduledoc """
+  FilterResult entity
+
+  A filter whose keywords matched a given status, part of `Hunter.Status`
+
+  ## Fields
+
+    * `filter` - the `Hunter.Filter` that was matched
+    * `keyword_matches` - the keywords within the filter that were matched,
+      if any
+    * `status_matches` - the status IDs within the filter that were matched,
+      if any
+
+  """
+
+  @type t :: %__MODULE__{
+          filter: Hunter.Filter.t(),
+          keyword_matches: [String.t()] | nil,
+          status_matches: [String.t()] | nil
+        }
+
+  @derive [Poison.Encoder]
+  defstruct [:filter, :keyword_matches, :status_matches]
+end

--- a/lib/hunter/filter_status.ex
+++ b/lib/hunter/filter_status.ex
@@ -1,0 +1,22 @@
+defmodule Hunter.FilterStatus do
+  @moduledoc """
+  FilterStatus entity
+
+  A status ID that, if matched, should cause the filter action to be taken,
+  part of `Hunter.Filter`
+
+  ## Fields
+
+    * `id` - the ID of the filter status
+    * `status_id` - the ID of the filtered status
+
+  """
+
+  @type t :: %__MODULE__{
+          id: String.t(),
+          status_id: String.t()
+        }
+
+  @derive [Poison.Encoder]
+  defstruct [:id, :status_id]
+end

--- a/lib/hunter/instance.ex
+++ b/lib/hunter/instance.ex
@@ -18,7 +18,7 @@ defmodule Hunter.Instance do
     * `configuration` - Configured values and limits for this instance
     * `registrations` - Information about registering for this instance
     * `contact` - Hints related to contacting a representative of the instance
-    * `rules` - An itemized list of rules for this instance
+    * `rules` - An itemized list of `Hunter.Rule` for this instance
 
   """
   alias Hunter.Config
@@ -35,7 +35,7 @@ defmodule Hunter.Instance do
           configuration: map,
           registrations: map,
           contact: map,
-          rules: [map]
+          rules: [Hunter.Rule.t()]
         }
 
   @derive [Poison.Encoder]

--- a/lib/hunter/list.ex
+++ b/lib/hunter/list.ex
@@ -1,0 +1,27 @@
+defmodule Hunter.List do
+  @moduledoc """
+  List entity
+
+  A list of some users that the authenticated user follows
+
+  ## Fields
+
+    * `id` - the ID of the list
+    * `title` - the user-defined title of the list
+    * `replies_policy` - which replies should be shown in the list, one of:
+      `followed`, `list`, `none`
+    * `exclusive` - whether members of the list are removed from the home
+      timeline
+
+  """
+
+  @type t :: %__MODULE__{
+          id: String.t(),
+          title: String.t(),
+          replies_policy: String.t(),
+          exclusive: boolean | nil
+        }
+
+  @derive [Poison.Encoder]
+  defstruct [:id, :title, :replies_policy, :exclusive]
+end

--- a/lib/hunter/marker.ex
+++ b/lib/hunter/marker.ex
@@ -1,0 +1,26 @@
+defmodule Hunter.Marker do
+  @moduledoc """
+  Marker entity
+
+  The last read position within a user's timeline; the markers endpoint
+  returns a map with `home` and/or `notifications` keys, each holding
+  one marker
+
+  ## Fields
+
+    * `last_read_id` - the ID of the most recently viewed entity
+    * `version` - incrementing counter, used for locking to prevent write
+      conflicts
+    * `updated_at` - when the marker was set
+
+  """
+
+  @type t :: %__MODULE__{
+          last_read_id: String.t(),
+          version: non_neg_integer,
+          updated_at: String.t()
+        }
+
+  @derive [Poison.Encoder]
+  defstruct [:last_read_id, :version, :updated_at]
+end

--- a/lib/hunter/notification.ex
+++ b/lib/hunter/notification.ex
@@ -8,10 +8,19 @@ defmodule Hunter.Notification do
   ## Fields
 
     * `id` - The notification ID
-    * `type` - One of: "mention", "reblog", "favourite", "follow"
+    * `type` - One of: "mention", "status", "reblog", "follow", "follow_request",
+      "favourite", "poll", "update", "admin.sign_up", "admin.report",
+      "severed_relationships", "moderation_warning", "quote", "quoted_update"
     * `created_at` - The time the notification was created
+    * `group_key` - Group key shared by similar notifications, used by
+      grouped notifications
     * `account` - The `Hunter.Account` sending the notification to the user
     * `status` - The `Hunter.Status` associated with the notification, if applicable
+    * `report` - The `Hunter.Report` associated with an "admin.report" notification
+    * `event` - Summary of the event that caused a "severed_relationships"
+      notification, if applicable
+    * `moderation_warning` - The moderation warning that caused a
+      "moderation_warning" notification, if applicable
 
   """
   alias Hunter.Config
@@ -20,12 +29,26 @@ defmodule Hunter.Notification do
           id: String.t(),
           type: String.t(),
           created_at: String.t(),
+          group_key: String.t() | nil,
           account: Hunter.Account.t(),
-          status: Hunter.Status.t()
+          status: Hunter.Status.t(),
+          report: Hunter.Report.t() | nil,
+          event: map | nil,
+          moderation_warning: map | nil
         }
 
   @derive [Poison.Encoder]
-  defstruct [:id, :type, :created_at, :account, :status]
+  defstruct [
+    :id,
+    :type,
+    :created_at,
+    :group_key,
+    :account,
+    :status,
+    :report,
+    :event,
+    :moderation_warning
+  ]
 
   @doc """
   Retrieve user's notifications

--- a/lib/hunter/notification_group.ex
+++ b/lib/hunter/notification_group.ex
@@ -1,0 +1,67 @@
+defmodule Hunter.NotificationGroup do
+  @moduledoc """
+  NotificationGroup entity
+
+  A group of related notifications, as returned by the grouped
+  notifications API
+
+  ## Fields
+
+    * `group_key` - group key identifying the grouped notifications; should
+      be treated as an opaque value
+    * `notifications_count` - total number of individual notifications that
+      are part of this group
+    * `type` - the type of event that resulted in the notifications, same
+      values as `Hunter.Notification` types
+    * `most_recent_notification_id` - ID of the most recent notification in
+      the group
+    * `page_min_id` - ID of the oldest notification from this group
+      represented within the current page
+    * `page_max_id` - ID of the newest notification from this group
+      represented within the current page
+    * `latest_page_notification_at` - date at which the most recent
+      notification within the current page was created
+    * `sample_account_ids` - IDs of some of the accounts who most recently
+      triggered notifications in this group
+    * `status_id` - ID of the `Hunter.Status` that was the object of the
+      notification, if applicable
+    * `report` - the report that was the object of the notification, for
+      `admin.report` notifications
+    * `event` - summary of the event that caused follow relationships to be
+      severed, for `severed_relationships` notifications
+    * `moderation_warning` - the moderation warning that caused the
+      notification, for `moderation_warning` notifications
+
+  """
+
+  @type t :: %__MODULE__{
+          group_key: String.t(),
+          notifications_count: non_neg_integer,
+          type: String.t(),
+          most_recent_notification_id: String.t(),
+          page_min_id: String.t() | nil,
+          page_max_id: String.t() | nil,
+          latest_page_notification_at: String.t() | nil,
+          sample_account_ids: [String.t()],
+          status_id: String.t() | nil,
+          report: Hunter.Report.t() | nil,
+          event: map | nil,
+          moderation_warning: map | nil
+        }
+
+  @derive [Poison.Encoder]
+  defstruct [
+    :group_key,
+    :notifications_count,
+    :type,
+    :most_recent_notification_id,
+    :page_min_id,
+    :page_max_id,
+    :latest_page_notification_at,
+    :sample_account_ids,
+    :status_id,
+    :report,
+    :event,
+    :moderation_warning
+  ]
+end

--- a/lib/hunter/notification_policy.ex
+++ b/lib/hunter/notification_policy.ex
@@ -1,0 +1,39 @@
+defmodule Hunter.NotificationPolicy do
+  @moduledoc """
+  NotificationPolicy entity
+
+  The filtering policy for notifications; each `for_*` field takes one of
+  `accept`, `filter` or `drop`
+
+  ## Fields
+
+    * `for_not_following` - policy for accounts the user is not following
+    * `for_not_followers` - policy for accounts not following the user
+    * `for_new_accounts` - policy for accounts created in the past 30 days
+    * `for_private_mentions` - policy for private mentions
+    * `for_limited_accounts` - policy for accounts limited by a moderator
+    * `summary` - map with `pending_requests_count` (number of accounts with
+      non-dismissed filtered notifications, capped at 100) and
+      `pending_notifications_count` keys
+
+  """
+
+  @type t :: %__MODULE__{
+          for_not_following: String.t(),
+          for_not_followers: String.t(),
+          for_new_accounts: String.t(),
+          for_private_mentions: String.t(),
+          for_limited_accounts: String.t(),
+          summary: map
+        }
+
+  @derive [Poison.Encoder]
+  defstruct [
+    :for_not_following,
+    :for_not_followers,
+    :for_new_accounts,
+    :for_private_mentions,
+    :for_limited_accounts,
+    :summary
+  ]
+end

--- a/lib/hunter/notification_request.ex
+++ b/lib/hunter/notification_request.ex
@@ -1,0 +1,33 @@
+defmodule Hunter.NotificationRequest do
+  @moduledoc """
+  NotificationRequest entity
+
+  Represents a group of filtered notifications from a specific user
+
+  ## Fields
+
+    * `id` - the ID of the notification request
+    * `created_at` - when the first filtered notification from that user was
+      created
+    * `updated_at` - when the notification request was last updated
+    * `account` - the `Hunter.Account` that performed the actions being
+      filtered
+    * `notifications_count` - how many of this account's notifications were
+      filtered, as a string
+    * `last_status` - the most recent `Hunter.Status` associated with a
+      filtered notification from the account, if any
+
+  """
+
+  @type t :: %__MODULE__{
+          id: String.t(),
+          created_at: String.t(),
+          updated_at: String.t(),
+          account: Hunter.Account.t(),
+          notifications_count: String.t(),
+          last_status: Hunter.Status.t() | nil
+        }
+
+  @derive [Poison.Encoder]
+  defstruct [:id, :created_at, :updated_at, :account, :notifications_count, :last_status]
+end

--- a/lib/hunter/poll.ex
+++ b/lib/hunter/poll.ex
@@ -47,27 +47,4 @@ defmodule Hunter.Poll do
     :voted,
     :own_votes
   ]
-
-  defmodule Option do
-    @moduledoc """
-    Poll option entity
-
-    A possible answer of a `Hunter.Poll`
-
-    ## Fields
-
-      * `title` - the text value of the poll option
-      * `votes_count` - the number of received votes for this option, `nil`
-        until the poll results are published
-
-    """
-
-    @type t :: %__MODULE__{
-            title: String.t(),
-            votes_count: non_neg_integer | nil
-          }
-
-    @derive [Poison.Encoder]
-    defstruct [:title, :votes_count]
-  end
 end

--- a/lib/hunter/poll.ex
+++ b/lib/hunter/poll.ex
@@ -1,0 +1,73 @@
+defmodule Hunter.Poll do
+  @moduledoc """
+  Poll entity
+
+  A poll attached to a `Hunter.Status`
+
+  ## Fields
+
+    * `id` - the ID of the poll
+    * `expires_at` - when the poll ends, if it has an end
+    * `expired` - whether the poll is currently expired
+    * `multiple` - whether the poll allows multiple-choice answers
+    * `votes_count` - how many votes have been received
+    * `voters_count` - how many unique accounts have voted, `nil` when the
+      poll is not multiple-choice
+    * `options` - list of `Hunter.Poll.Option`, the possible answers
+    * `emojis` - list of `Hunter.Emoji`, custom emoji used in the options
+    * `voted` - whether the authenticated user has voted (only with user token)
+    * `own_votes` - which options the authenticated user chose, by index
+      (only with user token)
+
+  """
+
+  @type t :: %__MODULE__{
+          id: String.t(),
+          expires_at: String.t() | nil,
+          expired: boolean,
+          multiple: boolean,
+          votes_count: non_neg_integer,
+          voters_count: non_neg_integer | nil,
+          options: [Hunter.Poll.Option.t()],
+          emojis: [Hunter.Emoji.t()],
+          voted: boolean | nil,
+          own_votes: [non_neg_integer] | nil
+        }
+
+  @derive [Poison.Encoder]
+  defstruct [
+    :id,
+    :expires_at,
+    :expired,
+    :multiple,
+    :votes_count,
+    :voters_count,
+    :options,
+    :emojis,
+    :voted,
+    :own_votes
+  ]
+
+  defmodule Option do
+    @moduledoc """
+    Poll option entity
+
+    A possible answer of a `Hunter.Poll`
+
+    ## Fields
+
+      * `title` - the text value of the poll option
+      * `votes_count` - the number of received votes for this option, `nil`
+        until the poll results are published
+
+    """
+
+    @type t :: %__MODULE__{
+            title: String.t(),
+            votes_count: non_neg_integer | nil
+          }
+
+    @derive [Poison.Encoder]
+    defstruct [:title, :votes_count]
+  end
+end

--- a/lib/hunter/poll/option.ex
+++ b/lib/hunter/poll/option.ex
@@ -1,0 +1,22 @@
+defmodule Hunter.Poll.Option do
+  @moduledoc """
+  Poll option entity
+
+  A possible answer of a `Hunter.Poll`
+
+  ## Fields
+
+    * `title` - the text value of the poll option
+    * `votes_count` - the number of received votes for this option, `nil`
+      until the poll results are published
+
+  """
+
+  @type t :: %__MODULE__{
+          title: String.t(),
+          votes_count: non_neg_integer | nil
+        }
+
+  @derive [Poison.Encoder]
+  defstruct [:title, :votes_count]
+end

--- a/lib/hunter/preferences.ex
+++ b/lib/hunter/preferences.ex
@@ -1,0 +1,40 @@
+defmodule Hunter.Preferences do
+  @moduledoc """
+  Preferences entity
+
+  The user's preferences for common client behaviors; the field names mirror
+  the colon-separated keys of the API response, so they must be accessed
+  with quoted-atom syntax, e.g. `preferences."posting:default:visibility"`
+
+  ## Fields
+
+    * `posting:default:visibility` - default visibility for new statuses,
+      one of: `public`, `unlisted`, `private`, `direct`
+    * `posting:default:sensitive` - whether new statuses are marked sensitive
+      by default
+    * `posting:default:language` - default language for new statuses, if set
+    * `reading:expand:media` - whether media attachments should be
+      automatically displayed or blurred/hidden, one of: `default`,
+      `show_all`, `hide_all`
+    * `reading:expand:spoilers` - whether content-warned statuses should be
+      expanded automatically
+
+  """
+
+  @type t :: %__MODULE__{
+          :"posting:default:visibility" => String.t(),
+          :"posting:default:sensitive" => boolean,
+          :"posting:default:language" => String.t() | nil,
+          :"reading:expand:media" => String.t(),
+          :"reading:expand:spoilers" => boolean
+        }
+
+  @derive [Poison.Encoder]
+  defstruct [
+    :"posting:default:visibility",
+    :"posting:default:sensitive",
+    :"posting:default:language",
+    :"reading:expand:media",
+    :"reading:expand:spoilers"
+  ]
+end

--- a/lib/hunter/privacy_policy.ex
+++ b/lib/hunter/privacy_policy.ex
@@ -1,0 +1,21 @@
+defmodule Hunter.PrivacyPolicy do
+  @moduledoc """
+  PrivacyPolicy entity
+
+  The privacy policy of the instance
+
+  ## Fields
+
+    * `updated_at` - when the content was last updated
+    * `content` - the rendered HTML content of the privacy policy
+
+  """
+
+  @type t :: %__MODULE__{
+          updated_at: String.t(),
+          content: String.t()
+        }
+
+  @derive [Poison.Encoder]
+  defstruct [:updated_at, :content]
+end

--- a/lib/hunter/quote.ex
+++ b/lib/hunter/quote.ex
@@ -1,0 +1,31 @@
+defmodule Hunter.Quote do
+  @moduledoc """
+  Quote entity
+
+  Information about a status quoting another status, part of `Hunter.Status`.
+
+  Covers both variants Mastodon returns: a full quote carries the quoted
+  status in `quoted_status`, while the shallow variant (used for nested
+  quotes) only carries `quoted_status_id`.
+
+  ## Fields
+
+    * `state` - state of the quote, one of: `pending`, `accepted`, `rejected`,
+      `revoked`, `deleted`, `unauthorized`, `blocked_account`,
+      `blocked_domain`, `muted_account`; unknown values should be treated
+      as `unauthorized`
+    * `quoted_status` - the `Hunter.Status` being quoted, `nil` unless the
+      state allows showing it
+    * `quoted_status_id` - the ID of the status being quoted (shallow variant)
+
+  """
+
+  @type t :: %__MODULE__{
+          state: String.t(),
+          quoted_status: Hunter.Status.t() | nil,
+          quoted_status_id: String.t() | nil
+        }
+
+  @derive [Poison.Encoder]
+  defstruct [:state, :quoted_status, :quoted_status_id]
+end

--- a/lib/hunter/relationship.ex
+++ b/lib/hunter/relationship.ex
@@ -9,11 +9,20 @@ defmodule Hunter.Relationship do
 
     * `id` - target account id
     * `following` - whether the user is currently following the account
+    * `showing_reblogs` - whether boosts from this account are shown in the home timeline
+    * `notifying` - whether the user has enabled notifications for this account
+    * `languages` - which languages the user is following this account for, if any
     * `followed_by` - whether the user is currently being followed by the account
     * `blocking` - whether the user is currently blocking the account
+    * `blocked_by` - whether the account is currently blocking the user
     * `muting` - whether the user is currently muting the account
+    * `muting_notifications` - whether the user is muting notifications from the account
+    * `muting_expires_at` - when the mute expires, if the mute is temporary
     * `requested` - whether the user has requested to follow the account
+    * `requested_by` - whether the account has requested to follow the user
     * `domain_blocking` - whether the user is currently blocking the user's domain
+    * `endorsed` - whether the user is featuring the account on their profile
+    * `note` - the user's private comment on the account
 
   """
   alias Hunter.Config
@@ -21,15 +30,41 @@ defmodule Hunter.Relationship do
   @type t :: %__MODULE__{
           id: non_neg_integer,
           following: boolean,
+          showing_reblogs: boolean,
+          notifying: boolean,
+          languages: [String.t()] | nil,
           followed_by: boolean,
           blocking: boolean,
+          blocked_by: boolean,
           muting: boolean,
+          muting_notifications: boolean,
+          muting_expires_at: String.t() | nil,
           requested: boolean,
-          domain_blocking: boolean
+          requested_by: boolean,
+          domain_blocking: boolean,
+          endorsed: boolean,
+          note: String.t()
         }
 
   @derive [Poison.Encoder]
-  defstruct [:id, :following, :followed_by, :blocking, :muting, :requested, :domain_blocking]
+  defstruct [
+    :id,
+    :following,
+    :showing_reblogs,
+    :notifying,
+    :languages,
+    :followed_by,
+    :blocking,
+    :blocked_by,
+    :muting,
+    :muting_notifications,
+    :muting_expires_at,
+    :requested,
+    :requested_by,
+    :domain_blocking,
+    :endorsed,
+    :note
+  ]
 
   @doc """
   Get the relationships of authenticated user towards given other users

--- a/lib/hunter/role.ex
+++ b/lib/hunter/role.ex
@@ -1,0 +1,24 @@
+defmodule Hunter.Role do
+  @moduledoc """
+  Role entity
+
+  A custom user role that grants permissions, shown on `Hunter.Account` as a
+  partial (only roles with a visible badge are returned)
+
+  ## Fields
+
+    * `id` - the ID of the role
+    * `name` - the name of the role
+    * `color` - the hex code assigned to this role, empty when no color
+
+  """
+
+  @type t :: %__MODULE__{
+          id: String.t(),
+          name: String.t(),
+          color: String.t()
+        }
+
+  @derive [Poison.Encoder]
+  defstruct [:id, :name, :color]
+end

--- a/lib/hunter/rule.ex
+++ b/lib/hunter/rule.ex
@@ -1,0 +1,23 @@
+defmodule Hunter.Rule do
+  @moduledoc """
+  Rule entity
+
+  A rule that server users should follow
+
+  ## Fields
+
+    * `id` - the ID of the rule
+    * `text` - the rule to be followed
+    * `hint` - longer-form description of the rule
+
+  """
+
+  @type t :: %__MODULE__{
+          id: String.t(),
+          text: String.t(),
+          hint: String.t() | nil
+        }
+
+  @derive [Poison.Encoder]
+  defstruct [:id, :text, :hint]
+end

--- a/lib/hunter/scheduled_status.ex
+++ b/lib/hunter/scheduled_status.ex
@@ -1,0 +1,28 @@
+defmodule Hunter.ScheduledStatus do
+  @moduledoc """
+  ScheduledStatus entity
+
+  A status that will be published at a future scheduled date
+
+  ## Fields
+
+    * `id` - the ID of the scheduled status
+    * `scheduled_at` - when the status will be published
+    * `params` - the parameters that were used when scheduling the status,
+      to be used when the status is posted (`text`, `visibility`, `poll`,
+      `media_ids`, etc.)
+    * `media_attachments` - list of `Hunter.Attachment` to be attached to
+      the status when posted
+
+  """
+
+  @type t :: %__MODULE__{
+          id: String.t(),
+          scheduled_at: String.t(),
+          params: map,
+          media_attachments: [Hunter.Attachment.t()]
+        }
+
+  @derive [Poison.Encoder]
+  defstruct [:id, :scheduled_at, :params, :media_attachments]
+end

--- a/lib/hunter/status.ex
+++ b/lib/hunter/status.ex
@@ -27,6 +27,22 @@ defmodule Hunter.Status do
     * `application` - `Hunter.Application` from which the status was posted
     * `language` - detected language for the status, default: en
     * `card` - preview card generated for links in the status, if any
+    * `emojis` - list of `Hunter.Emoji`, custom emoji used in the status
+    * `text` - plain-text source of the status, returned instead of `content`
+      when the status is deleted
+    * `created_at` - time the status was created
+    * `edited_at` - time of the most recent edit, `nil` if never edited
+    * `replies_count` - number of replies to the status
+    * `bookmarked` - whether the authenticated user has bookmarked the status
+    * `pinned` - whether the authenticated user has pinned the status (only
+      present on the user's own statuses)
+    * `poll` - the `Hunter.Poll` attached to the status, if any
+    * `filtered` - list of `Hunter.FilterResult`, filters that matched the
+      status for the authenticated user
+    * `quote` - the `Hunter.Quote` of another status, if any
+    * `quote_approval` - summary of the status' quote approval policy and how
+      it applies to the requesting user (`automatic`, `manual` and
+      `current_user` keys)
 
   **NOTE**: When `spoiler_text` is present, `sensitive` is true
 
@@ -39,22 +55,34 @@ defmodule Hunter.Status do
           url: String.t(),
           account: Hunter.Account.t(),
           in_reply_to_id: non_neg_integer,
+          in_reply_to_account_id: non_neg_integer,
           reblog: Hunter.Status.t() | nil,
           content: String.t(),
+          text: String.t() | nil,
           created_at: String.t(),
+          edited_at: String.t() | nil,
           reblogs_count: non_neg_integer,
           favourites_count: non_neg_integer,
+          replies_count: non_neg_integer,
           reblogged: boolean,
           favourited: boolean,
+          bookmarked: boolean,
+          pinned: boolean | nil,
           muted: boolean,
           sensitive: boolean,
           spoiler_text: String.t(),
+          visibility: String.t(),
           media_attachments: [Hunter.Attachment.t()],
           mentions: [Hunter.Mention.t()],
           tags: [Hunter.Tag.t()],
+          emojis: [Hunter.Emoji.t()],
           application: Hunter.Application.t(),
           language: String.t(),
-          card: Hunter.Card.t() | nil
+          card: Hunter.Card.t() | nil,
+          poll: Hunter.Poll.t() | nil,
+          filtered: [Hunter.FilterResult.t()] | nil,
+          quote: Hunter.Quote.t() | nil,
+          quote_approval: map | nil
         }
 
   @type status_id :: non_neg_integer
@@ -69,11 +97,16 @@ defmodule Hunter.Status do
     :in_reply_to_account_id,
     :reblog,
     :content,
+    :text,
     :created_at,
+    :edited_at,
     :reblogs_count,
     :favourites_count,
+    :replies_count,
     :reblogged,
     :favourited,
+    :bookmarked,
+    :pinned,
     :muted,
     :sensitive,
     :spoiler_text,
@@ -81,9 +114,14 @@ defmodule Hunter.Status do
     :media_attachments,
     :mentions,
     :tags,
+    :emojis,
     :application,
     :language,
-    :card
+    :card,
+    :poll,
+    :filtered,
+    :quote,
+    :quote_approval
   ]
 
   @doc """

--- a/lib/hunter/suggestion.ex
+++ b/lib/hunter/suggestion.ex
@@ -1,0 +1,27 @@
+defmodule Hunter.Suggestion do
+  @moduledoc """
+  Suggestion entity
+
+  A suggested account to follow, with a reason for the suggestion
+
+  ## Fields
+
+    * `source` - the reason this account is being suggested, one of: `staff`,
+      `past_interactions`, `global` (deprecated since Mastodon 4.3 in favor
+      of `sources`)
+    * `sources` - reasons this account is being suggested, list of:
+      `featured`, `most_followed`, `most_interactions`,
+      `similar_to_recently_followed`, `friends_of_friends`
+    * `account` - the `Hunter.Account` being recommended to follow
+
+  """
+
+  @type t :: %__MODULE__{
+          source: String.t(),
+          sources: [String.t()],
+          account: Hunter.Account.t()
+        }
+
+  @derive [Poison.Encoder]
+  defstruct [:source, :sources, :account]
+end

--- a/lib/hunter/tag.ex
+++ b/lib/hunter/tag.ex
@@ -4,16 +4,26 @@ defmodule Hunter.Tag do
 
   ## Fields
 
+    * `id` - Database ID of the hashtag, useful for Admin API URLs
     * `name` - The hashtag, not including the preceding `#`
     * `url` - The URL of the hashtag
+    * `history` - usage statistics for given days (last 7), a list of maps
+      with `day`, `uses` and `accounts` keys
+    * `following` - whether the current authorized user is following this tag
+    * `featuring` - whether the current authorized user is featuring this tag
+      on their profile
 
   """
 
   @type t :: %__MODULE__{
+          id: String.t() | nil,
           name: String.t(),
-          url: String.t()
+          url: String.t(),
+          history: [map] | nil,
+          following: boolean | nil,
+          featuring: boolean | nil
         }
 
   @derive [Poison.Encoder]
-  defstruct [:name, :url]
+  defstruct [:id, :name, :url, :history, :following, :featuring]
 end

--- a/lib/hunter/terms_of_service.ex
+++ b/lib/hunter/terms_of_service.ex
@@ -1,0 +1,27 @@
+defmodule Hunter.TermsOfService do
+  @moduledoc """
+  TermsOfService entity
+
+  The terms of service of the instance
+
+  ## Fields
+
+    * `effective_date` - the date these terms of service are/were coming
+      into effect
+    * `effective` - whether these terms of service are currently in effect
+    * `content` - the rendered HTML content of the terms of service
+    * `succeeded_by` - if there are newer terms of service, their effective
+      date
+
+  """
+
+  @type t :: %__MODULE__{
+          effective_date: String.t(),
+          effective: boolean,
+          content: String.t(),
+          succeeded_by: String.t() | nil
+        }
+
+  @derive [Poison.Encoder]
+  defstruct [:effective_date, :effective, :content, :succeeded_by]
+end

--- a/lib/hunter/translation.ex
+++ b/lib/hunter/translation.ex
@@ -1,0 +1,43 @@
+defmodule Hunter.Translation do
+  @moduledoc """
+  Translation entity
+
+  The translation of a status into some language, as returned by the
+  status translate endpoint
+
+  ## Fields
+
+    * `content` - HTML-encoded translated content of the status
+    * `spoiler_text` - translated spoiler warning of the status
+    * `poll` - translated poll options, a map with `id` and `options` keys,
+      if the status has a poll
+    * `media_attachments` - translated media descriptions, a list of maps
+      with `id` and `description` keys
+    * `language` - the language of the source text, as provided by the
+      translation provider
+    * `detected_source_language` - the language detected in the source text
+    * `provider` - the service that provided the machine translation
+
+  """
+
+  @type t :: %__MODULE__{
+          content: String.t(),
+          spoiler_text: String.t(),
+          poll: map | nil,
+          media_attachments: [map],
+          language: String.t(),
+          detected_source_language: String.t(),
+          provider: String.t()
+        }
+
+  @derive [Poison.Encoder]
+  defstruct [
+    :content,
+    :spoiler_text,
+    :poll,
+    :media_attachments,
+    :language,
+    :detected_source_language,
+    :provider
+  ]
+end

--- a/lib/hunter/web_push_subscription.ex
+++ b/lib/hunter/web_push_subscription.ex
@@ -1,0 +1,31 @@
+defmodule Hunter.WebPushSubscription do
+  @moduledoc """
+  WebPushSubscription entity
+
+  A subscription to the Web Push API
+
+  ## Fields
+
+    * `id` - the ID of the Web Push subscription in the database
+    * `endpoint` - where push alerts will be sent to
+    * `standard` - whether the subscription uses standardized web push
+      (RFC 8030, 8291 and 8292) or legacy web push drafts
+    * `server_key` - the streaming server's VAPID key
+    * `alerts` - map of notification types to booleans, which alerts should
+      be delivered to the endpoint (`mention`, `status`, `reblog`, `follow`,
+      `follow_request`, `favourite`, `poll`, `update`, `admin.sign_up`,
+      `admin.report`)
+
+  """
+
+  @type t :: %__MODULE__{
+          id: String.t(),
+          endpoint: String.t(),
+          standard: boolean,
+          server_key: String.t(),
+          alerts: map
+        }
+
+  @derive [Poison.Encoder]
+  defstruct [:id, :endpoint, :standard, :server_key, :alerts]
+end

--- a/test/fixtures/account.json
+++ b/test/fixtures/account.json
@@ -4,7 +4,16 @@
   "acct": "milmazz",
   "display_name": "Milton Mazzarri",
   "locked": false,
+  "bot": false,
+  "group": false,
+  "discoverable": true,
+  "noindex": false,
+  "suspended": false,
+  "limited": false,
   "created_at": "2017-04-06T13:15:24.420Z",
+  "last_status_at": "2026-07-01",
+  "hide_collections": false,
+  "uri": "https://mastodon.example/users/milmazz",
   "followers_count": 118,
   "following_count": 178,
   "statuses_count": 33,
@@ -14,12 +23,28 @@
   "avatar_static": "https://mastodon.example/avatars/original/missing.png",
   "header": "https://mastodon.example/headers/original/missing.png",
   "header_static": "https://mastodon.example/headers/original/missing.png",
+  "attribution_domains": ["milmazz.uno"],
+  "fields": [
+    {
+      "name": "Website",
+      "value": "<a href=\"https://milmazz.uno\">milmazz.uno</a>",
+      "verified_at": "2026-01-15T10:00:00.000Z"
+    }
+  ],
+  "roles": [
+    {
+      "id": "3",
+      "name": "Owner",
+      "color": "#ff3838"
+    }
+  ],
   "emojis": [
     {
       "shortcode": "blobcat",
       "url": "https://mastodon.example/emojis/blobcat.png",
       "static_url": "https://mastodon.example/emojis/blobcat_static.png",
-      "visible_in_picker": true
+      "visible_in_picker": true,
+      "category": "cats"
     }
   ]
 }

--- a/test/fixtures/announcement.json
+++ b/test/fixtures/announcement.json
@@ -1,0 +1,40 @@
+{
+  "id": "8",
+  "content": "<p>Looking at the online migration tooling this week</p>",
+  "starts_at": null,
+  "ends_at": null,
+  "all_day": false,
+  "published_at": "2026-07-01T04:20:00.000Z",
+  "updated_at": "2026-07-01T04:20:00.000Z",
+  "read": true,
+  "mentions": [
+    {
+      "id": "8039",
+      "username": "kadaba",
+      "url": "https://mastodon.example/@kadaba",
+      "acct": "kadaba"
+    }
+  ],
+  "statuses": [
+    {
+      "id": "103270115826048975",
+      "url": "https://mastodon.example/@milmazz/103270115826048975"
+    }
+  ],
+  "tags": [
+    {
+      "name": "elixir",
+      "url": "https://mastodon.example/tags/elixir"
+    }
+  ],
+  "emojis": [],
+  "reactions": [
+    {
+      "name": "bongoCat",
+      "count": 9,
+      "me": false,
+      "url": "https://mastodon.example/emojis/bongo_cat.png",
+      "static_url": "https://mastodon.example/emojis/bongo_cat_static.png"
+    }
+  ]
+}

--- a/test/fixtures/annual_report.json
+++ b/test/fixtures/annual_report.json
@@ -1,0 +1,14 @@
+{
+  "year": 2025,
+  "schema_version": 2,
+  "share_url": "https://mastodon.example/@milmazz/wrapstodon/2025",
+  "account_id": "23634",
+  "data": {
+    "archetype": "oracle",
+    "time_series": [
+      { "month": 1, "statuses": 10, "followers": 5, "following": 2 }
+    ],
+    "top_hashtags": [{ "name": "elixir", "count": 11 }],
+    "top_statuses": { "by_reblogs": "103270115826048975" }
+  }
+}

--- a/test/fixtures/attachment.json
+++ b/test/fixtures/attachment.json
@@ -4,9 +4,12 @@
   "url": "https://mastodon.example/media/image.png",
   "preview_url": "https://mastodon.example/media/image_small.png",
   "remote_url": null,
+  "preview_remote_url": null,
   "text_url": "https://mastodon.example/media/xYzabc",
   "meta": {
-    "original": { "width": 640, "height": 480 }
+    "original": { "width": 640, "height": 480 },
+    "focus": { "x": 0.5, "y": -0.5 }
   },
-  "description": "test media"
+  "description": "test media",
+  "blurhash": "UBL_:rOpGG-;~qRjWBay0fM{ofofoLWBWVj["
 }

--- a/test/fixtures/collection.json
+++ b/test/fixtures/collection.json
@@ -1,0 +1,24 @@
+{
+  "id": "118",
+  "account_id": "23634",
+  "uri": "https://mastodon.example/collections/118",
+  "url": "https://mastodon.example/@milmazz/collections/118",
+  "name": "Elixir folks",
+  "description": "<p>People who talk about Elixir</p>",
+  "language": "en",
+  "local": true,
+  "sensitive": false,
+  "discoverable": true,
+  "tag": null,
+  "created_at": "2026-07-01T04:20:00.000Z",
+  "updated_at": "2026-07-01T04:20:00.000Z",
+  "item_count": 1,
+  "items": [
+    {
+      "id": "310",
+      "account_id": "8039",
+      "state": "accepted",
+      "created_at": "2026-07-01T04:20:00.000Z"
+    }
+  ]
+}

--- a/test/fixtures/conversation.json
+++ b/test/fixtures/conversation.json
@@ -1,0 +1,16 @@
+{
+  "id": "418450",
+  "unread": true,
+  "accounts": [
+    {
+      "id": "8039",
+      "username": "kadaba",
+      "acct": "kadaba"
+    }
+  ],
+  "last_status": {
+    "id": "103270115826048975",
+    "content": "<p>hello @milmazz</p>",
+    "visibility": "direct"
+  }
+}

--- a/test/fixtures/domain_block.json
+++ b/test/fixtures/domain_block.json
@@ -1,0 +1,6 @@
+{
+  "domain": "spam.example",
+  "digest": "d048b7c07bc27eae7b1a75bbf7f09701b6a7442f22cfa1eeb0903b4ec66230d5",
+  "severity": "suspend",
+  "comment": "spam instance"
+}

--- a/test/fixtures/extended_description.json
+++ b/test/fixtures/extended_description.json
@@ -1,0 +1,4 @@
+{
+  "updated_at": "2026-06-15T00:00:00.000Z",
+  "content": "<p>For inquiries please reach out to the admin.</p>"
+}

--- a/test/fixtures/featured_tag.json
+++ b/test/fixtures/featured_tag.json
@@ -1,0 +1,7 @@
+{
+  "id": "627",
+  "name": "elixir",
+  "url": "https://mastodon.example/@milmazz/tagged/elixir",
+  "statuses_count": 20,
+  "last_status_at": "2026-07-01"
+}

--- a/test/fixtures/filter.json
+++ b/test/fixtures/filter.json
@@ -1,0 +1,13 @@
+{
+  "id": "19972",
+  "title": "Test filter",
+  "context": ["home"],
+  "expires_at": "2026-09-20T17:27:39.296Z",
+  "filter_action": "warn",
+  "keywords": [
+    { "id": "1197", "keyword": "bad word", "whole_word": false }
+  ],
+  "statuses": [
+    { "id": "1", "status_id": "109031743575371913" }
+  ]
+}

--- a/test/fixtures/list.json
+++ b/test/fixtures/list.json
@@ -1,0 +1,6 @@
+{
+  "id": "12249",
+  "title": "Friends",
+  "replies_policy": "followed",
+  "exclusive": false
+}

--- a/test/fixtures/markers.json
+++ b/test/fixtures/markers.json
@@ -1,0 +1,12 @@
+{
+  "home": {
+    "last_read_id": "103270115826048975",
+    "version": 462,
+    "updated_at": "2026-07-01T15:07:11.000Z"
+  },
+  "notifications": {
+    "last_read_id": "34975861",
+    "version": 361,
+    "updated_at": "2026-07-01T15:07:11.000Z"
+  }
+}

--- a/test/fixtures/notification.json
+++ b/test/fixtures/notification.json
@@ -2,6 +2,7 @@
   "id": "34975861",
   "type": "mention",
   "created_at": "2019-11-23T07:49:02.064Z",
+  "group_key": "ungrouped-34975861",
   "account": {
     "id": "8039",
     "username": "kadaba",
@@ -11,5 +12,8 @@
     "id": "103270115826048975",
     "content": "<p>hello @milmazz</p>",
     "visibility": "public"
-  }
+  },
+  "report": null,
+  "event": null,
+  "moderation_warning": null
 }

--- a/test/fixtures/notification_group.json
+++ b/test/fixtures/notification_group.json
@@ -1,0 +1,11 @@
+{
+  "group_key": "favourite-103270115826048975",
+  "notifications_count": 2,
+  "type": "favourite",
+  "most_recent_notification_id": "196014",
+  "page_min_id": "196013",
+  "page_max_id": "196014",
+  "latest_page_notification_at": "2026-07-01T04:20:00.000Z",
+  "sample_account_ids": ["8039", "23634"],
+  "status_id": "103270115826048975"
+}

--- a/test/fixtures/notification_policy.json
+++ b/test/fixtures/notification_policy.json
@@ -1,0 +1,11 @@
+{
+  "for_not_following": "accept",
+  "for_not_followers": "accept",
+  "for_new_accounts": "accept",
+  "for_private_mentions": "filter",
+  "for_limited_accounts": "filter",
+  "summary": {
+    "pending_requests_count": 3,
+    "pending_notifications_count": 17
+  }
+}

--- a/test/fixtures/notification_request.json
+++ b/test/fixtures/notification_request.json
@@ -1,0 +1,16 @@
+{
+  "id": "112456967201894256",
+  "created_at": "2026-07-01T04:20:00.000Z",
+  "updated_at": "2026-07-01T04:20:00.000Z",
+  "notifications_count": "5",
+  "account": {
+    "id": "8039",
+    "username": "kadaba",
+    "acct": "kadaba"
+  },
+  "last_status": {
+    "id": "103270115826048975",
+    "content": "<p>hello @milmazz</p>",
+    "visibility": "public"
+  }
+}

--- a/test/fixtures/poll.json
+++ b/test/fixtures/poll.json
@@ -1,0 +1,15 @@
+{
+  "id": "34830",
+  "expires_at": "2026-07-10T04:20:00.000Z",
+  "expired": false,
+  "multiple": false,
+  "votes_count": 10,
+  "voters_count": 10,
+  "voted": true,
+  "own_votes": [1],
+  "options": [
+    { "title": "accept", "votes_count": 6 },
+    { "title": "deny", "votes_count": 4 }
+  ],
+  "emojis": []
+}

--- a/test/fixtures/preferences.json
+++ b/test/fixtures/preferences.json
@@ -1,0 +1,7 @@
+{
+  "posting:default:visibility": "public",
+  "posting:default:sensitive": false,
+  "posting:default:language": null,
+  "reading:expand:media": "default",
+  "reading:expand:spoilers": false
+}

--- a/test/fixtures/privacy_policy.json
+++ b/test/fixtures/privacy_policy.json
@@ -1,0 +1,4 @@
+{
+  "updated_at": "2026-06-15T00:00:00.000Z",
+  "content": "<p>This privacy policy describes how the instance collects data.</p>"
+}

--- a/test/fixtures/relationship.json
+++ b/test/fixtures/relationship.json
@@ -1,9 +1,18 @@
 {
   "id": "8039",
   "following": true,
+  "showing_reblogs": true,
+  "notifying": false,
+  "languages": ["en", "es"],
   "followed_by": false,
   "blocking": false,
+  "blocked_by": false,
   "muting": false,
+  "muting_notifications": false,
+  "muting_expires_at": null,
   "requested": false,
-  "domain_blocking": false
+  "requested_by": false,
+  "domain_blocking": false,
+  "endorsed": false,
+  "note": "college friend"
 }

--- a/test/fixtures/rule.json
+++ b/test/fixtures/rule.json
@@ -1,0 +1,5 @@
+{
+  "id": "2",
+  "text": "No racism, sexism, homophobia, transphobia, xenophobia, or casteism.",
+  "hint": "Transphobic behavior includes intentional misgendering and deadnaming."
+}

--- a/test/fixtures/scheduled_status.json
+++ b/test/fixtures/scheduled_status.json
@@ -1,0 +1,20 @@
+{
+  "id": "3221",
+  "scheduled_at": "2026-07-20T13:00:00.000Z",
+  "params": {
+    "text": "test content",
+    "visibility": "public",
+    "scheduled_at": null,
+    "poll": null,
+    "idempotency": null,
+    "with_rate_limit": false
+  },
+  "media_attachments": [
+    {
+      "id": "22345792",
+      "type": "image",
+      "url": "https://mastodon.example/media/image.png",
+      "preview_url": "https://mastodon.example/media/image_small.png"
+    }
+  ]
+}

--- a/test/fixtures/status.json
+++ b/test/fixtures/status.json
@@ -6,11 +6,16 @@
   "in_reply_to_account_id": null,
   "reblog": null,
   "content": "<p>Testing <a href=\"https://mastodon.example/tags/elixir\">#elixir</a> with @kadaba</p>",
+  "text": null,
   "created_at": "2019-12-08T03:48:33.901Z",
+  "edited_at": "2026-06-30T12:00:00.000Z",
   "reblogs_count": 6,
   "favourites_count": 11,
+  "replies_count": 2,
   "reblogged": false,
   "favourited": false,
+  "bookmarked": true,
+  "pinned": false,
   "muted": false,
   "sensitive": false,
   "spoiler_text": "",
@@ -28,7 +33,8 @@
       "id": "22345792",
       "type": "image",
       "url": "https://mastodon.example/media/image.png",
-      "preview_url": "https://mastodon.example/media/image_small.png"
+      "preview_url": "https://mastodon.example/media/image_small.png",
+      "blurhash": "UBL_:rOpGG-;~qRjWBay0fM{ofofoLWBWVj["
     }
   ],
   "mentions": [
@@ -41,19 +47,80 @@
   ],
   "tags": [
     {
+      "id": "541",
       "name": "elixir",
-      "url": "https://mastodon.example/tags/elixir"
+      "url": "https://mastodon.example/tags/elixir",
+      "history": [
+        { "day": "1751241600", "uses": "24", "accounts": "18" }
+      ],
+      "following": true,
+      "featuring": false
+    }
+  ],
+  "emojis": [
+    {
+      "shortcode": "blobcat",
+      "url": "https://mastodon.example/emojis/blobcat.png",
+      "static_url": "https://mastodon.example/emojis/blobcat_static.png",
+      "visible_in_picker": true,
+      "category": "cats"
     }
   ],
   "application": {
     "name": "hunter",
     "website": null
   },
+  "poll": {
+    "id": "34830",
+    "expires_at": "2026-07-10T04:20:00.000Z",
+    "expired": false,
+    "multiple": false,
+    "votes_count": 10,
+    "voters_count": 10,
+    "voted": false,
+    "own_votes": [],
+    "options": [
+      { "title": "accept", "votes_count": 6 },
+      { "title": "deny", "votes_count": 4 }
+    ],
+    "emojis": []
+  },
+  "filtered": [
+    {
+      "filter": {
+        "id": "19972",
+        "title": "Test filter",
+        "context": ["home"],
+        "expires_at": null,
+        "filter_action": "warn"
+      },
+      "keyword_matches": ["bad word"],
+      "status_matches": null
+    }
+  ],
+  "quote": {
+    "state": "accepted",
+    "quoted_status_id": "103270115826048000"
+  },
+  "quote_approval": {
+    "automatic": ["public"],
+    "manual": [],
+    "current_user": "automatic"
+  },
   "card": {
     "url": "https://elixir-lang.org/",
     "title": "The Elixir programming language",
     "description": "Elixir is a dynamic, functional language.",
     "type": "link",
-    "image": "https://mastodon.example/preview_cards/image.png"
+    "image": "https://mastodon.example/preview_cards/image.png",
+    "blurhash": "UBL_:rOpGG-;~qRjWBay0fM{ofofoLWBWVj[",
+    "embed_url": "",
+    "authors": [
+      {
+        "name": "José Valim",
+        "url": "https://mastodon.example/@josevalim",
+        "account": null
+      }
+    ]
   }
 }

--- a/test/fixtures/suggestion.json
+++ b/test/fixtures/suggestion.json
@@ -1,0 +1,9 @@
+{
+  "source": "past_interactions",
+  "sources": ["similar_to_recently_followed"],
+  "account": {
+    "id": "8039",
+    "username": "kadaba",
+    "acct": "kadaba"
+  }
+}

--- a/test/fixtures/terms_of_service.json
+++ b/test/fixtures/terms_of_service.json
@@ -1,0 +1,6 @@
+{
+  "effective_date": "2026-06-15",
+  "effective": true,
+  "content": "<p>Foo bar newer</p>",
+  "succeeded_by": null
+}

--- a/test/fixtures/translation.json
+++ b/test/fixtures/translation.json
@@ -1,0 +1,11 @@
+{
+  "content": "<p>Hola mundo</p>",
+  "spoiler_text": "",
+  "media_attachments": [
+    { "id": "22345792", "description": "prueba de medios" }
+  ],
+  "poll": null,
+  "language": "es",
+  "detected_source_language": "en",
+  "provider": "DeepL.com"
+}

--- a/test/fixtures/web_push_subscription.json
+++ b/test/fixtures/web_push_subscription.json
@@ -1,0 +1,18 @@
+{
+  "id": "328183",
+  "endpoint": "https://yourdomain.example/listener",
+  "standard": true,
+  "server_key": "BCk-QqERU0q-CfYZjcuB6lnyyOYfJ2AifKqfeGIm7Z-HiTU5T9eTG5GxVA0_OH5mMlI4UkkDTpaZwozy0TzdZ2M=",
+  "alerts": {
+    "mention": true,
+    "status": false,
+    "reblog": false,
+    "follow": true,
+    "follow_request": false,
+    "favourite": true,
+    "poll": false,
+    "update": false,
+    "admin.sign_up": false,
+    "admin.report": false
+  }
+}

--- a/test/hunter/api/transformer_test.exs
+++ b/test/hunter/api/transformer_test.exs
@@ -13,7 +13,28 @@ defmodule Hunter.Api.TransformerTest do
     assert account.followers_count == 118
     assert account.url == "https://mastodon.example/@milmazz"
 
-    assert [%Hunter.Emoji{shortcode: "blobcat", visible_in_picker: true}] = account.emojis
+    assert [%Hunter.Emoji{shortcode: "blobcat", visible_in_picker: true, category: "cats"}] =
+             account.emojis
+  end
+
+  test "decodes modern account fields" do
+    account = transform("account", :account)
+
+    assert account.bot == false
+    assert account.group == false
+    assert account.discoverable == true
+    assert account.noindex == false
+    assert account.suspended == false
+    assert account.limited == false
+    assert account.last_status_at == "2026-07-01"
+    assert account.hide_collections == false
+    assert account.uri == "https://mastodon.example/users/milmazz"
+    assert account.attribution_domains == ["milmazz.uno"]
+
+    assert [%Hunter.Field{name: "Website", verified_at: "2026-01-15T10:00:00.000Z"}] =
+             account.fields
+
+    assert [%Hunter.Role{id: "3", name: "Owner", color: "#ff3838"}] = account.roles
   end
 
   test "decodes a list of accounts" do
@@ -34,6 +55,89 @@ defmodule Hunter.Api.TransformerTest do
     assert status.reblog == nil
   end
 
+  test "decodes modern status fields" do
+    status = transform("status", :status)
+
+    assert status.edited_at == "2026-06-30T12:00:00.000Z"
+    assert status.bookmarked == true
+    assert status.pinned == false
+    assert status.replies_count == 2
+    assert status.text == nil
+
+    assert [%Hunter.Emoji{shortcode: "blobcat"}] = status.emojis
+
+    assert [%Hunter.Tag{id: "541", following: true, featuring: false, history: [history]}] =
+             status.tags
+
+    assert history["uses"] == "24"
+
+    assert [%Hunter.Attachment{blurhash: "UBL_:rOpGG-;~qRjWBay0fM{ofofoLWBWVj["}] =
+             status.media_attachments
+
+    assert %Hunter.Card{embed_url: "", blurhash: "UBL_:rOpGG-;~qRjWBay0fM{ofofoLWBWVj["} =
+             status.card
+
+    assert [%Hunter.Card.Author{name: "José Valim", account: nil}] = status.card.authors
+
+    assert %Hunter.Poll{id: "34830", multiple: false, votes_count: 10} = status.poll
+    assert [%Hunter.Poll.Option{title: "accept", votes_count: 6} | _] = status.poll.options
+
+    assert [%Hunter.FilterResult{keyword_matches: ["bad word"]} = filter_result] =
+             status.filtered
+
+    assert %Hunter.Filter{id: "19972", filter_action: "warn"} = filter_result.filter
+
+    assert %Hunter.Quote{state: "accepted", quoted_status_id: "103270115826048000"} =
+             status.quote
+
+    assert status.quote_approval["current_user"] == "automatic"
+  end
+
+  test "decodes a poll" do
+    poll = transform("poll", :poll)
+
+    assert %Hunter.Poll{id: "34830", expired: false, voters_count: 10} = poll
+    assert poll.voted == true
+    assert poll.own_votes == [1]
+    assert [%Hunter.Poll.Option{title: "accept", votes_count: 6}, _] = poll.options
+  end
+
+  test "decodes a filter with keywords and statuses" do
+    filter = transform("filter", :filter)
+
+    assert %Hunter.Filter{id: "19972", title: "Test filter", context: ["home"]} = filter
+    assert [%Hunter.FilterKeyword{keyword: "bad word", whole_word: false}] = filter.keywords
+    assert [%Hunter.FilterStatus{status_id: "109031743575371913"}] = filter.statuses
+  end
+
+  test "decodes a list of filters" do
+    assert [%Hunter.Filter{title: "Test filter"}] = transform_list("filter", :filters)
+  end
+
+  test "decodes a translation" do
+    translation = transform("translation", :translation)
+
+    assert %Hunter.Translation{language: "es", detected_source_language: "en"} = translation
+    assert translation.content == "<p>Hola mundo</p>"
+    assert translation.provider == "DeepL.com"
+    assert [%{"description" => "prueba de medios"}] = translation.media_attachments
+  end
+
+  test "decodes a scheduled status" do
+    scheduled = transform("scheduled_status", :scheduled_status)
+
+    assert %Hunter.ScheduledStatus{id: "3221", scheduled_at: "2026-07-20T13:00:00.000Z"} =
+             scheduled
+
+    assert scheduled.params["text"] == "test content"
+    assert [%Hunter.Attachment{id: "22345792", type: "image"}] = scheduled.media_attachments
+  end
+
+  test "decodes a list of scheduled statuses" do
+    assert [%Hunter.ScheduledStatus{id: "3221"}] =
+             transform_list("scheduled_status", :scheduled_statuses)
+  end
+
   test "decodes a list of statuses" do
     assert [%Hunter.Status{account: %Hunter.Account{username: "milmazz"}}] =
              transform_list("status", :statuses)
@@ -45,6 +149,10 @@ defmodule Hunter.Api.TransformerTest do
     assert %Hunter.Notification{type: "mention"} = notification
     assert %Hunter.Account{username: "kadaba"} = notification.account
     assert %Hunter.Status{content: "<p>hello @milmazz</p>"} = notification.status
+    assert notification.group_key == "ungrouped-34975861"
+    assert notification.report == nil
+    assert notification.event == nil
+    assert notification.moderation_warning == nil
   end
 
   test "decodes a list of notifications" do
@@ -66,17 +174,104 @@ defmodule Hunter.Api.TransformerTest do
     assert %Hunter.Instance{domain: "mastodon.example", version: "4.3.8"} = instance
     assert instance.contact["email"] == "admin@mastodon.example"
     assert instance.configuration["urls"]["streaming"] == "wss://mastodon.example"
-    assert [%{"text" => "Be excellent to each other"}] = instance.rules
+    assert [%Hunter.Rule{text: "Be excellent to each other"}] = instance.rules
   end
 
   test "decodes a relationship" do
-    assert %Hunter.Relationship{following: true, blocking: false} =
-             transform("relationship", :relationship)
+    relationship = transform("relationship", :relationship)
+
+    assert %Hunter.Relationship{following: true, blocking: false} = relationship
+    assert relationship.showing_reblogs == true
+    assert relationship.notifying == false
+    assert relationship.languages == ["en", "es"]
+    assert relationship.blocked_by == false
+    assert relationship.muting_notifications == false
+    assert relationship.muting_expires_at == nil
+    assert relationship.requested_by == false
+    assert relationship.endorsed == false
+    assert relationship.note == "college friend"
   end
 
   test "decodes a list of relationships" do
     assert [%Hunter.Relationship{following: true}] =
              transform_list("relationship", :relationships)
+  end
+
+  test "decodes a list" do
+    assert %Hunter.List{id: "12249", title: "Friends", replies_policy: "followed"} =
+             transform("list", :list)
+  end
+
+  test "decodes a list of lists" do
+    assert [%Hunter.List{title: "Friends", exclusive: false}] = transform_list("list", :lists)
+  end
+
+  test "decodes a conversation with nested accounts and last status" do
+    conversation = transform("conversation", :conversation)
+
+    assert %Hunter.Conversation{id: "418450", unread: true} = conversation
+    assert [%Hunter.Account{username: "kadaba"}] = conversation.accounts
+    assert %Hunter.Status{visibility: "direct"} = conversation.last_status
+  end
+
+  test "decodes a list of conversations" do
+    assert [%Hunter.Conversation{id: "418450"}] =
+             transform_list("conversation", :conversations)
+  end
+
+  test "decodes markers keyed by timeline" do
+    markers = transform("markers", :markers)
+
+    assert %Hunter.Marker{last_read_id: "103270115826048975", version: 462} = markers["home"]
+    assert %Hunter.Marker{last_read_id: "34975861"} = markers["notifications"]
+  end
+
+  test "decodes a suggestion" do
+    suggestion = transform("suggestion", :suggestion)
+
+    assert %Hunter.Suggestion{sources: ["similar_to_recently_followed"]} = suggestion
+    assert %Hunter.Account{username: "kadaba"} = suggestion.account
+  end
+
+  test "decodes a list of suggestions" do
+    assert [%Hunter.Suggestion{source: "past_interactions"}] =
+             transform_list("suggestion", :suggestions)
+  end
+
+  test "decodes a featured tag" do
+    featured_tag = transform("featured_tag", :featured_tag)
+
+    assert %Hunter.FeaturedTag{id: "627", name: "elixir", statuses_count: 20} = featured_tag
+    assert featured_tag.last_status_at == "2026-07-01"
+  end
+
+  test "decodes a list of featured tags" do
+    assert [%Hunter.FeaturedTag{name: "elixir"}] =
+             transform_list("featured_tag", :featured_tags)
+  end
+
+  test "decodes an announcement with reactions" do
+    announcement = transform("announcement", :announcement)
+
+    assert %Hunter.Announcement{id: "8", all_day: false, read: true} = announcement
+    assert [%{"username" => "kadaba"}] = announcement.mentions
+    assert [%Hunter.Tag{name: "elixir"}] = announcement.tags
+
+    assert [%Hunter.Announcement.Reaction{name: "bongoCat", count: 9, me: false}] =
+             announcement.reactions
+  end
+
+  test "decodes a list of announcements" do
+    assert [%Hunter.Announcement{id: "8"}] = transform_list("announcement", :announcements)
+  end
+
+  test "decodes preferences" do
+    preferences = transform("preferences", :preferences)
+
+    assert %Hunter.Preferences{} = preferences
+    assert preferences."posting:default:visibility" == "public"
+    assert preferences."posting:default:sensitive" == false
+    assert preferences."reading:expand:media" == "default"
   end
 
   test "decodes a report" do
@@ -99,6 +294,119 @@ defmodule Hunter.Api.TransformerTest do
 
     assert %Hunter.Attachment{type: "image", description: "test media"} = attachment
     assert attachment.meta["original"]["width"] == 640
+    assert attachment.meta["focus"]["x"] == 0.5
+    assert attachment.blurhash == "UBL_:rOpGG-;~qRjWBay0fM{ofofoLWBWVj["
+    assert attachment.preview_remote_url == nil
+  end
+
+  test "decodes a notification policy" do
+    policy = transform("notification_policy", :notification_policy)
+
+    assert %Hunter.NotificationPolicy{for_not_following: "accept"} = policy
+    assert policy.for_private_mentions == "filter"
+    assert policy.summary["pending_requests_count"] == 3
+  end
+
+  test "decodes a notification request with nested account and status" do
+    request = transform("notification_request", :notification_request)
+
+    assert %Hunter.NotificationRequest{id: "112456967201894256"} = request
+    assert request.notifications_count == "5"
+    assert %Hunter.Account{username: "kadaba"} = request.account
+    assert %Hunter.Status{visibility: "public"} = request.last_status
+  end
+
+  test "decodes a list of notification requests" do
+    assert [%Hunter.NotificationRequest{notifications_count: "5"}] =
+             transform_list("notification_request", :notification_requests)
+  end
+
+  test "decodes a notification group" do
+    group = transform("notification_group", :notification_group)
+
+    assert %Hunter.NotificationGroup{type: "favourite", notifications_count: 2} = group
+    assert group.group_key == "favourite-103270115826048975"
+    assert group.sample_account_ids == ["8039", "23634"]
+    assert group.status_id == "103270115826048975"
+  end
+
+  test "decodes a web push subscription" do
+    subscription = transform("web_push_subscription", :web_push_subscription)
+
+    assert %Hunter.WebPushSubscription{id: "328183", standard: true} = subscription
+    assert subscription.alerts["mention"] == true
+    assert subscription.alerts["admin.report"] == false
+  end
+
+  test "decodes a rule" do
+    rule = transform("rule", :rule)
+
+    assert %Hunter.Rule{id: "2"} = rule
+    assert rule.text =~ "No racism"
+    assert rule.hint =~ "Transphobic behavior"
+  end
+
+  test "decodes a list of rules" do
+    assert [%Hunter.Rule{id: "2"}] = transform_list("rule", :rules)
+  end
+
+  test "decodes an extended description" do
+    assert %Hunter.ExtendedDescription{updated_at: "2026-06-15T00:00:00.000Z"} =
+             transform("extended_description", :extended_description)
+  end
+
+  test "decodes a privacy policy" do
+    assert %Hunter.PrivacyPolicy{updated_at: "2026-06-15T00:00:00.000Z"} =
+             transform("privacy_policy", :privacy_policy)
+  end
+
+  test "decodes terms of service" do
+    terms = transform("terms_of_service", :terms_of_service)
+
+    assert %Hunter.TermsOfService{effective_date: "2026-06-15", effective: true} = terms
+    assert terms.succeeded_by == nil
+  end
+
+  test "decodes a domain block" do
+    domain_block = transform("domain_block", :domain_block)
+
+    assert %Hunter.DomainBlock{domain: "spam.example", severity: "suspend"} = domain_block
+    assert domain_block.comment == "spam instance"
+  end
+
+  test "decodes a list of domain blocks" do
+    assert [%Hunter.DomainBlock{domain: "spam.example"}] =
+             transform_list("domain_block", :domain_blocks)
+  end
+
+  test "decodes a collection with items" do
+    collection = transform("collection", :collection)
+
+    assert %Hunter.Collection{id: "118", name: "Elixir folks", item_count: 1} = collection
+    assert collection.local == true
+
+    assert [%Hunter.Collection.Item{id: "310", account_id: "8039", state: "accepted"}] =
+             collection.items
+  end
+
+  test "decodes an annual report" do
+    annual_report = transform("annual_report", :annual_report)
+
+    assert %Hunter.AnnualReport{year: 2025, schema_version: 2} = annual_report
+    assert annual_report.account_id == "23634"
+    assert annual_report.data["archetype"] == "oracle"
+  end
+
+  test "decodes an application with modern fields" do
+    application =
+      Transformer.transform(
+        ~s({"name": "hunter", "website": null, "scopes": ["read"], "redirect_uris": ["urn:ietf:wg:oauth:2.0:oob"], "client_id": "abc", "client_secret": "def", "client_secret_expires_at": 0}),
+        :application
+      )
+
+    assert %Hunter.Application{name: "hunter", scopes: ["read"]} = application
+    assert application.redirect_uris == ["urn:ietf:wg:oauth:2.0:oob"]
+    assert application.client_secret_expires_at == 0
   end
 
   test "falls back to a plain map for unknown entities" do

--- a/test/hunter/application_test.exs
+++ b/test/hunter/application_test.exs
@@ -83,7 +83,7 @@ defmodule Hunter.ApplicationTest do
            } =
              app = Hunter.Application.load_credentials(app_name)
 
-    assert Map.equal?(Map.from_struct(app), expected)
+    assert Map.take(Map.from_struct(app), Map.keys(expected)) == expected
 
     Application.put_env(:hunter, :home, home)
   end


### PR DESCRIPTION
Closes #119

Brings every Hunter entity struct up to the Mastodon 4.6 shapes, and adds structs for the entities returned by endpoints Hunter doesn't implement yet — the prerequisite for the rest of the parity backlog (#120–#127, #3).

## Existing structs extended

| Struct | New fields |
|---|---|
| `Hunter.Status` | `text`, `edited_at`, `replies_count`, `bookmarked`, `pinned`, `emojis`, `poll`, `filtered`, `quote`, `quote_approval` (+ `in_reply_to_account_id`/`visibility` added to the typespec) |
| `Hunter.Account` | `uri`, `last_status_at`, `group`, `discoverable`, `noindex`, `suspended`, `limited`, `hide_collections`, `roles`, `attribution_domains`, `source`; `fields` now decodes into `Hunter.Field` structs |
| `Hunter.Relationship` | `showing_reblogs`, `notifying`, `languages`, `blocked_by`, `muting_notifications`, `muting_expires_at` (4.6), `requested_by`, `endorsed`, `note` |
| `Hunter.Notification` | `group_key`, `report` (decoded as `Hunter.Report`), `event`, `moderation_warning`; documented the full set of modern `type` values |
| `Hunter.Tag` | `id`, `history`, `following`, `featuring` |
| `Hunter.Card` | `blurhash`, `embed_url`, `authors` (list of new `Hunter.Card.Author`), plus `published_at`/`history` (trending-links variant) |
| `Hunter.Attachment` | `blurhash`, `preview_remote_url`; `meta` typespec corrected to map |
| `Hunter.Emoji` | `category` |
| `Hunter.Application` | `name`, `website`, `redirect_uris`, `client_secret_expires_at` — now covers the 4.3 `CredentialApplication` shape |
| `Hunter.Instance` | `rules` now decodes into `Hunter.Rule` structs |

## New entity structs (27 modules)

`Poll` (+`Poll.Option`), `Quote` (covers the shallow variant via `quoted_status_id`), `Filter`, `FilterKeyword`, `FilterStatus`, `FilterResult`, `Translation`, `ScheduledStatus`, `List`, `Conversation`, `Marker`, `Suggestion`, `FeaturedTag`, `Announcement` (+`Announcement.Reaction`), `Preferences`, `Field`, `Role`, `NotificationPolicy`, `NotificationRequest`, `NotificationGroup`, `WebPushSubscription`, `Rule`, `ExtendedDescription`, `PrivacyPolicy`, `TermsOfService`, `DomainBlock`, `Collection` (+`Collection.Item`), `AnnualReport`.

`Hunter.Api.Transformer` gains decode clauses (single + list where applicable) and nested-struct specs for all of them; every clause is covered by a fixture-driven test (fixtures follow the shapes documented at docs.joinmastodon.org/entities, verified against the live docs during this work).

## Notes & deviations from the issue checklist

- **No `image_description` on `Card`**: the issue listed it, but the PreviewCard entity docs have no such attribute — verified against the live page, so it was dropped.
- **No separate `CredentialApplication` module**: `Hunter.Application` already mixed both shapes (it's what `create_app` returns and `load_credentials` reads), so it was extended in place instead of splitting.
- **Maps instead of structs** for a few deliberately unmodeled shapes: `quote_approval`, notification `event`/`moderation_warning`, `Translation.poll`/`media_attachments`, `Preferences` uses quoted-atom fields mirroring the API's colon-separated keys.
- **New entity IDs are typed `String.t()`** (what the API actually returns); the pre-existing `non_neg_integer` ids are #116's cleanup and were left alone.
- **`.credo.exs` added**: `Credo.Check.Warning.StructFieldAmount` limit raised to 40, since `Status` legitimately has 33 fields imposed by the upstream entity.

## Testing

- 110 tests + 4 doctests, 0 failures (31 new transformer tests, all written red-first against the fixtures)
- `mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix credo --strict`, `mix dialyzer`, `mix deps.unlock --check-unused` all pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
