### PR TITLE
Status parity: editing, bookmarks, pins, translate, polls, media management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 ## Unreleased
 
   * Features
+    - Status parity endpoints ([#120]): `edit_status/4`, `status_history/2`,
+      `status_source/2`, `bookmark/2`, `unbookmark/2`, `bookmarks/2`,
+      `pin/2`, `unpin/2`, `mute_conversation/2`, `unmute_conversation/2`,
+      `translate_status/3` and `statuses_by_ids/2` (all also exposed on the
+      `Hunter` facade)
+    - Polls ([#120]): `Hunter.Poll.poll/2` and `Hunter.Poll.vote/3`, plus
+      the `poll` option on `create_status`
+    - `create_status` upgrades ([#120]): `language` and `quoted_status_id`
+      options; `scheduled_at` returns a `Hunter.ScheduledStatus`;
+      `idempotency_key` is sent as the `Idempotency-Key` header
+    - Media management ([#120]): `media_attachment/2` (processing status of
+      async uploads), `update_media/3` and `delete_media/2`
+    - New entities `Hunter.StatusSource` and `Hunter.StatusEdit` backing the
+      status source/history endpoints ([#120])
     - Modernized the existing entity structs to the Mastodon 4.6 shapes
       ([#119]):
       - `Hunter.Status`: `text`, `edited_at`, `replies_count`, `bookmarked`,
@@ -40,6 +54,7 @@
       (and `Hunter.Collection.Item`), `Hunter.AnnualReport`
 
 [#119]: https://github.com/milmazz/hunter/issues/119
+[#120]: https://github.com/milmazz/hunter/issues/120
 
 ## v0.6.0
 

--- a/README.md
+++ b/README.md
@@ -249,6 +249,49 @@ iex> Hunter.unfavourite(conn, 442)
 
  Returns the target `Hunter.Status`
 
+### Editing a status
+
+```elixir
+iex> Hunter.edit_status(conn, 442, "corrected text", language: "en")
+%Hunter.Status{content: "<p>corrected text</p>", edited_at: "2026-07-08T12:00:00.000Z", ...}
+
+iex> Hunter.status_source(conn, 442)
+%Hunter.StatusSource{id: "442", text: "corrected text", spoiler_text: ""}
+
+iex> Hunter.status_history(conn, 442)
+[%Hunter.StatusEdit{content: "<p>original text</p>", ...}, %Hunter.StatusEdit{...}]
+```
+
+### Bookmarking a status
+
+```elixir
+iex> Hunter.bookmark(conn, 442)
+%Hunter.Status{bookmarked: true, ...}
+
+iex> Hunter.bookmarks(conn)
+[%Hunter.Status{bookmarked: true, ...}]
+
+iex> Hunter.unbookmark(conn, 442)
+%Hunter.Status{bookmarked: false, ...}
+```
+
+Statuses can also be pinned to your profile (`Hunter.pin/2`, `Hunter.unpin/2`)
+and their threads muted (`Hunter.mute_conversation/2`,
+`Hunter.unmute_conversation/2`).
+
+### Polls
+
+```elixir
+iex> Hunter.create_status(conn, "which one?", poll: %{options: ["yes", "no"], expires_in: 3600})
+%Hunter.Status{poll: %Hunter.Poll{id: "34830", ...}, ...}
+
+iex> Hunter.vote(conn, 34_830, [0])
+%Hunter.Poll{voted: true, own_votes: [0], votes_count: 1, ...}
+
+iex> Hunter.poll(conn, 34_830)
+%Hunter.Poll{expired: false, votes_count: 1, ...}
+```
+
 ### Get instance information
 
 ```elixir

--- a/lib/hunter.ex
+++ b/lib/hunter.ex
@@ -273,6 +273,50 @@ defmodule Hunter do
   defdelegate upload_media(conn, file, options \\ []), to: Hunter.Attachment
 
   @doc """
+  Retrieve a media attachment, to check the processing status of an
+  asynchronous upload
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `id` - attachment identifier
+
+  """
+  @spec media_attachment(Hunter.Client.t(), non_neg_integer) :: Hunter.Attachment.t()
+  defdelegate media_attachment(conn, id), to: Hunter.Attachment
+
+  @doc """
+  Update a media attachment, before it is attached to a status
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `id` - attachment identifier
+    * `options` - option list
+
+  ## Options
+
+    * `description` - plain-text description of the media for accessibility
+    * `focus` - two floating points between -1.0 and 1.0, comma-delimited
+    * `thumbnail` - path of a custom thumbnail image
+
+  """
+  @spec update_media(Hunter.Client.t(), non_neg_integer, Keyword.t()) :: Hunter.Attachment.t()
+  defdelegate update_media(conn, id, options \\ []), to: Hunter.Attachment
+
+  @doc """
+  Delete a media attachment that is not currently attached to a status
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `id` - attachment identifier
+
+  """
+  @spec delete_media(Hunter.Client.t(), non_neg_integer) :: boolean
+  defdelegate delete_media(conn, id), to: Hunter.Attachment
+
+  @doc """
   Get the relationships of authenticated user towards given other users
 
   ## Parameters
@@ -387,10 +431,45 @@ defmodule Hunter do
     * `sensitive` - whether the media of the status is NSFW
     * `spoiler_text` - text to be shown as a warning before the actual content
     * `visibility` - either `direct`, `private`, `unlisted` or `public`
+    * `language` - ISO 639-1 language code for the status
+    * `poll` - map with `options` (list of choices) and `expires_in`
+      (seconds); optional: `multiple`, `hide_totals`
+    * `quoted_status_id` - ID of a status to quote
+    * `scheduled_at` - ISO 8601 datetime (at least 5 minutes ahead) at which
+      the status should be published; the call returns a
+      `Hunter.ScheduledStatus` instead of a `Hunter.Status`
+    * `idempotency_key` - unique string sent as the `Idempotency-Key` header
+      to prevent duplicate submissions
 
   """
-  @spec create_status(Hunter.Client.t(), String.t(), Keyword.t()) :: Hunter.Status.t() | no_return
+  @spec create_status(Hunter.Client.t(), String.t(), Keyword.t()) ::
+          Hunter.Status.t() | Hunter.ScheduledStatus.t() | no_return
   defdelegate create_status(conn, status, options \\ []), to: Hunter.Status
+
+  @doc """
+  Retrieve a poll
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `id` - poll identifier
+
+  """
+  @spec poll(Hunter.Client.t(), non_neg_integer) :: Hunter.Poll.t()
+  defdelegate poll(conn, id), to: Hunter.Poll
+
+  @doc """
+  Vote on one or more options in a poll
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `id` - poll identifier
+    * `choices` - list of option indices to vote for (zero-based)
+
+  """
+  @spec vote(Hunter.Client.t(), non_neg_integer, [non_neg_integer]) :: Hunter.Poll.t()
+  defdelegate vote(conn, id, choices), to: Hunter.Poll
 
   @doc """
   Retrieve status
@@ -403,6 +482,177 @@ defmodule Hunter do
   """
   @spec status(Hunter.Client.t(), non_neg_integer) :: Hunter.Status.t()
   defdelegate status(conn, id), to: Hunter.Status
+
+  @doc """
+  Retrieve multiple statuses by id
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `ids` - list of status identifiers
+
+  """
+  @spec statuses_by_ids(Hunter.Client.t(), [non_neg_integer]) :: [Hunter.Status.t()]
+  defdelegate statuses_by_ids(conn, ids), to: Hunter.Status
+
+  @doc """
+  Edit a status
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `id` - status identifier
+    * `status` - the new text of the status
+    * `options` - option list
+
+  ## Options
+
+    * `spoiler_text` - text to be shown as a warning before the actual content
+    * `sensitive` - whether the media of the status is NSFW
+    * `language` - ISO 639-1 language code for the status
+    * `media_ids` - list of media IDs to attach to the status
+    * `poll` - map with `options` (list of choices) and `expires_in`
+      (seconds); replaces the current poll
+
+  """
+  @spec edit_status(Hunter.Client.t(), non_neg_integer, String.t(), Keyword.t()) ::
+          Hunter.Status.t() | no_return
+  defdelegate edit_status(conn, id, status, options \\ []), to: Hunter.Status
+
+  @doc """
+  Retrieve the edit history of a status
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `id` - status identifier
+
+  """
+  @spec status_history(Hunter.Client.t(), non_neg_integer) :: [Hunter.StatusEdit.t()]
+  defdelegate status_history(conn, id), to: Hunter.Status
+
+  @doc """
+  Retrieve the plain-text source of a status, for editing
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `id` - status identifier
+
+  """
+  @spec status_source(Hunter.Client.t(), non_neg_integer) :: Hunter.StatusSource.t()
+  defdelegate status_source(conn, id), to: Hunter.Status
+
+  @doc """
+  Bookmark a status
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `id` - status identifier
+
+  """
+  @spec bookmark(Hunter.Client.t(), non_neg_integer) :: Hunter.Status.t()
+  defdelegate bookmark(conn, id), to: Hunter.Status
+
+  @doc """
+  Remove a status from bookmarks
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `id` - status identifier
+
+  """
+  @spec unbookmark(Hunter.Client.t(), non_neg_integer) :: Hunter.Status.t()
+  defdelegate unbookmark(conn, id), to: Hunter.Status
+
+  @doc """
+  Fetch the user's bookmarked statuses
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `options` - option list
+
+  ## Options
+
+    * `max_id` - get a list of bookmarks with id less than or equal this value
+    * `since_id` - get a list of bookmarks with id greater than this value
+    * `min_id` - get a list of bookmarks with id greater than this value,
+      immediately newer
+    * `limit` - maximum number of bookmarks to get, default: 20, max: 40
+
+  """
+  @spec bookmarks(Hunter.Client.t(), Keyword.t()) :: [Hunter.Status.t()]
+  defdelegate bookmarks(conn, options \\ []), to: Hunter.Status
+
+  @doc """
+  Pin a status to the top of the user's profile
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `id` - status identifier
+
+  """
+  @spec pin(Hunter.Client.t(), non_neg_integer) :: Hunter.Status.t()
+  defdelegate pin(conn, id), to: Hunter.Status
+
+  @doc """
+  Unpin a status from the user's profile
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `id` - status identifier
+
+  """
+  @spec unpin(Hunter.Client.t(), non_neg_integer) :: Hunter.Status.t()
+  defdelegate unpin(conn, id), to: Hunter.Status
+
+  @doc """
+  Mute a conversation, so its thread stops generating notifications
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `id` - status identifier
+
+  """
+  @spec mute_conversation(Hunter.Client.t(), non_neg_integer) :: Hunter.Status.t()
+  defdelegate mute_conversation(conn, id), to: Hunter.Status
+
+  @doc """
+  Unmute a conversation
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `id` - status identifier
+
+  """
+  @spec unmute_conversation(Hunter.Client.t(), non_neg_integer) :: Hunter.Status.t()
+  defdelegate unmute_conversation(conn, id), to: Hunter.Status
+
+  @doc """
+  Translate a status into some language
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `id` - status identifier
+    * `options` - option list
+
+  ## Options
+
+    * `lang` - ISO 639-1 language code the status should be translated into;
+      defaults to the user's current locale
+
+  """
+  @spec translate_status(Hunter.Client.t(), non_neg_integer, Keyword.t()) ::
+          Hunter.Translation.t()
+  defdelegate translate_status(conn, id, options \\ []), to: Hunter.Status
 
   @doc """
   Destroy status

--- a/lib/hunter/api.ex
+++ b/lib/hunter/api.ex
@@ -203,6 +203,52 @@ defmodule Hunter.Api do
             ) :: Hunter.Application.t()
 
   @doc """
+  Retrieve a media attachment, to check the processing status of an
+  asynchronous upload
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `id` - attachment identifier
+
+  """
+  @callback media_attachment(conn :: Hunter.Client.t(), id :: non_neg_integer) ::
+              Hunter.Attachment.t()
+
+  @doc """
+  Update a media attachment, before it is attached to a status
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `id` - attachment identifier
+    * `options` - option list
+
+  ## Options
+
+    * `description` - plain-text description of the media for accessibility
+    * `focus` - two floating points between -1.0 and 1.0, comma-delimited
+    * `thumbnail` - path of a custom thumbnail image
+
+  """
+  @callback update_media(
+              conn :: Hunter.Client.t(),
+              id :: non_neg_integer,
+              options :: Keyword.t()
+            ) :: Hunter.Attachment.t()
+
+  @doc """
+  Delete a media attachment that is not currently attached to a status
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `id` - attachment identifier
+
+  """
+  @callback delete_media(conn :: Hunter.Client.t(), id :: non_neg_integer) :: boolean
+
+  @doc """
   Upload a media file
 
   ## Parameters
@@ -336,10 +382,19 @@ defmodule Hunter.Api do
     * `sensitive` - whether the media of the status is NSFW
     * `spoiler_text` - text to be shown as a warning before the actual content
     * `visibility` - either `direct`, `private`, `unlisted` or `public`
+    * `language` - ISO 639-1 language code for the status
+    * `poll` - map with `options` (list of choices) and `expires_in`
+      (seconds); optional: `multiple`, `hide_totals`
+    * `quoted_status_id` - ID of a status to quote
+    * `scheduled_at` - ISO 8601 datetime (at least 5 minutes ahead) at which
+      the status should be published; the call returns a
+      `Hunter.ScheduledStatus` instead of a `Hunter.Status`
+    * `idempotency_key` - unique string sent as the `Idempotency-Key` header
+      to prevent duplicate submissions
 
   """
   @callback create_status(conn :: Hunter.Client.t(), status :: String.t(), options :: Keyword.t()) ::
-              Hunter.Status.t() | no_return
+              Hunter.Status.t() | Hunter.ScheduledStatus.t() | no_return
 
   @doc """
   Retrieve status
@@ -351,6 +406,203 @@ defmodule Hunter.Api do
 
   """
   @callback status(conn :: Hunter.Client.t(), id :: non_neg_integer) :: Hunter.Status.t()
+
+  @doc """
+  Retrieve multiple statuses by id
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `ids` - list of status identifiers
+
+  """
+  @callback statuses_by_ids(conn :: Hunter.Client.t(), ids :: [non_neg_integer]) :: [
+              Hunter.Status.t()
+            ]
+
+  @doc """
+  Edit a status
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `id` - status identifier
+    * `status` - the new text of the status
+    * `options` - option list
+
+  ## Options
+
+    * `spoiler_text` - text to be shown as a warning before the actual content
+    * `sensitive` - whether the media of the status is NSFW
+    * `language` - ISO 639-1 language code for the status
+    * `media_ids` - list of media IDs to attach to the status
+    * `poll` - map with `options` (list of choices) and `expires_in`
+      (seconds); replaces the current poll
+
+  """
+  @callback edit_status(
+              conn :: Hunter.Client.t(),
+              id :: non_neg_integer,
+              status :: String.t(),
+              options :: Keyword.t()
+            ) :: Hunter.Status.t() | no_return
+
+  @doc """
+  Retrieve the edit history of a status
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `id` - status identifier
+
+  """
+  @callback status_history(conn :: Hunter.Client.t(), id :: non_neg_integer) :: [
+              Hunter.StatusEdit.t()
+            ]
+
+  @doc """
+  Retrieve the plain-text source of a status, for editing
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `id` - status identifier
+
+  """
+  @callback status_source(conn :: Hunter.Client.t(), id :: non_neg_integer) ::
+              Hunter.StatusSource.t()
+
+  @doc """
+  Bookmark a status
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `id` - status identifier
+
+  """
+  @callback bookmark(conn :: Hunter.Client.t(), id :: non_neg_integer) :: Hunter.Status.t()
+
+  @doc """
+  Remove a status from bookmarks
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `id` - status identifier
+
+  """
+  @callback unbookmark(conn :: Hunter.Client.t(), id :: non_neg_integer) :: Hunter.Status.t()
+
+  @doc """
+  Fetch the user's bookmarked statuses
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `options` - option list
+
+  ## Options
+
+    * `max_id` - get a list of bookmarks with id less than or equal this value
+    * `since_id` - get a list of bookmarks with id greater than this value
+    * `min_id` - get a list of bookmarks with id greater than this value,
+      immediately newer
+    * `limit` - maximum number of bookmarks to get, default: 20, max: 40
+
+  """
+  @callback bookmarks(conn :: Hunter.Client.t(), options :: Keyword.t()) :: [Hunter.Status.t()]
+
+  @doc """
+  Pin a status to the top of the user's profile
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `id` - status identifier
+
+  """
+  @callback pin(conn :: Hunter.Client.t(), id :: non_neg_integer) :: Hunter.Status.t()
+
+  @doc """
+  Unpin a status from the user's profile
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `id` - status identifier
+
+  """
+  @callback unpin(conn :: Hunter.Client.t(), id :: non_neg_integer) :: Hunter.Status.t()
+
+  @doc """
+  Mute a conversation, so its thread stops generating notifications
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `id` - status identifier
+
+  """
+  @callback mute_conversation(conn :: Hunter.Client.t(), id :: non_neg_integer) ::
+              Hunter.Status.t()
+
+  @doc """
+  Unmute a conversation
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `id` - status identifier
+
+  """
+  @callback unmute_conversation(conn :: Hunter.Client.t(), id :: non_neg_integer) ::
+              Hunter.Status.t()
+
+  @doc """
+  Translate a status into some language
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `id` - status identifier
+    * `options` - option list
+
+  ## Options
+
+    * `lang` - ISO 639-1 language code the status should be translated into;
+      defaults to the user's current locale
+
+  """
+  @callback translate_status(
+              conn :: Hunter.Client.t(),
+              id :: non_neg_integer,
+              options :: Keyword.t()
+            ) :: Hunter.Translation.t()
+
+  @doc """
+  Retrieve a poll
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `id` - poll identifier
+
+  """
+  @callback poll(conn :: Hunter.Client.t(), id :: non_neg_integer) :: Hunter.Poll.t()
+
+  @doc """
+  Vote on one or more options in a poll
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `id` - poll identifier
+    * `choices` - list of option indices to vote for (zero-based)
+
+  """
+  @callback vote(conn :: Hunter.Client.t(), id :: non_neg_integer, choices :: [non_neg_integer]) ::
+              Hunter.Poll.t()
 
   @doc """
   Destroy status

--- a/lib/hunter/api/http_client.ex
+++ b/lib/hunter/api/http_client.ex
@@ -99,6 +99,24 @@ defmodule Hunter.Api.HTTPClient do
     |> request!(:attachment, :post, {:multipart, options}, headers)
   end
 
+  def media_attachment(conn, id) do
+    "/api/v1/media/#{id}"
+    |> process_url(conn)
+    |> request!(:attachment, :get, [], conn)
+  end
+
+  def update_media(conn, id, options) do
+    "/api/v1/media/#{id}"
+    |> process_url(conn)
+    |> request!(:attachment, :put, Map.new(options), conn)
+  end
+
+  def delete_media(conn, id) do
+    "/api/v1/media/#{id}"
+    |> process_url(conn)
+    |> request!(nil, :delete, [], conn)
+  end
+
   def relationships(conn, ids) do
     "/api/v1/accounts/relationships"
     |> process_url(conn)
@@ -150,11 +168,33 @@ defmodule Hunter.Api.HTTPClient do
   end
 
   def create_status(conn, status, options) do
+    {idempotency_key, options} = Keyword.pop(options, :idempotency_key)
     body = options |> Keyword.put(:status, status) |> Map.new()
+
+    headers =
+      case idempotency_key do
+        nil -> get_headers(conn)
+        key -> get_headers(conn) ++ [{:"Idempotency-Key", key}]
+      end
+
+    # scheduling a status returns a ScheduledStatus instead of a Status
+    to = if Keyword.has_key?(options, :scheduled_at), do: :scheduled_status, else: :status
 
     "/api/v1/statuses"
     |> process_url(conn)
-    |> request!(:status, :post, body, conn)
+    |> request!(to, :post, body, headers)
+  end
+
+  def poll(conn, id) do
+    "/api/v1/polls/#{id}"
+    |> process_url(conn)
+    |> request!(:poll, :get, [], conn)
+  end
+
+  def vote(conn, id, choices) do
+    "/api/v1/polls/#{id}/votes"
+    |> process_url(conn)
+    |> request!(:poll, :post, %{choices: choices}, conn)
   end
 
   def status(conn, id) do
@@ -167,6 +207,62 @@ defmodule Hunter.Api.HTTPClient do
     "/api/v1/statuses/#{id}"
     |> process_url(conn)
     |> request!(nil, :delete, [], conn)
+  end
+
+  def statuses_by_ids(conn, ids) do
+    "/api/v1/statuses"
+    |> process_url(conn)
+    |> request!(:statuses, :get, %{id: ids}, conn)
+  end
+
+  def edit_status(conn, id, status, options) do
+    body = options |> Keyword.put(:status, status) |> Map.new()
+
+    "/api/v1/statuses/#{id}"
+    |> process_url(conn)
+    |> request!(:status, :put, body, conn)
+  end
+
+  def status_history(conn, id) do
+    "/api/v1/statuses/#{id}/history"
+    |> process_url(conn)
+    |> request!(:status_edits, :get, [], conn)
+  end
+
+  def status_source(conn, id) do
+    "/api/v1/statuses/#{id}/source"
+    |> process_url(conn)
+    |> request!(:status_source, :get, [], conn)
+  end
+
+  def bookmark(conn, id), do: status_action(conn, id, :bookmark)
+
+  def unbookmark(conn, id), do: status_action(conn, id, :unbookmark)
+
+  def pin(conn, id), do: status_action(conn, id, :pin)
+
+  def unpin(conn, id), do: status_action(conn, id, :unpin)
+
+  def mute_conversation(conn, id), do: status_action(conn, id, :mute)
+
+  def unmute_conversation(conn, id), do: status_action(conn, id, :unmute)
+
+  defp status_action(conn, id, action) do
+    "/api/v1/statuses/#{id}/#{action}"
+    |> process_url(conn)
+    |> request!(:status, :post, [], conn)
+  end
+
+  def bookmarks(conn, options) do
+    "/api/v1/bookmarks"
+    |> process_url(conn)
+    |> request!(:statuses, :get, options, conn)
+  end
+
+  def translate_status(conn, id, options) do
+    "/api/v1/statuses/#{id}/translate"
+    |> process_url(conn)
+    |> request!(:translation, :post, Map.new(options), conn)
   end
 
   def reblog(conn, id) do

--- a/lib/hunter/api/transformer.ex
+++ b/lib/hunter/api/transformer.ex
@@ -32,6 +32,21 @@ defmodule Hunter.Api.Transformer do
 
   def transform(body, :statuses), do: Poison.decode!(body, as: [status_nested_struct()])
 
+  def transform(body, :status_source), do: Poison.decode!(body, as: %Hunter.StatusSource{})
+
+  def transform(body, :status_edits) do
+    Poison.decode!(
+      body,
+      as: [
+        %Hunter.StatusEdit{
+          account: account_nested_struct(),
+          media_attachments: [%Hunter.Attachment{}],
+          emojis: [%Hunter.Emoji{}]
+        }
+      ]
+    )
+  end
+
   def transform(body, :notification_policy),
     do: Poison.decode!(body, as: %Hunter.NotificationPolicy{})
 

--- a/lib/hunter/attachment.ex
+++ b/lib/hunter/attachment.ex
@@ -78,4 +78,54 @@ defmodule Hunter.Attachment do
   def upload_media(conn, file, options \\ []) do
     Config.hunter_api().upload_media(conn, file, options)
   end
+
+  @doc """
+  Retrieve a media attachment, to check the processing status of an
+  asynchronous upload
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `id` - attachment identifier
+
+  """
+  @spec media_attachment(Hunter.Client.t(), non_neg_integer) :: Hunter.Attachment.t()
+  def media_attachment(conn, id) do
+    Config.hunter_api().media_attachment(conn, id)
+  end
+
+  @doc """
+  Update a media attachment, before it is attached to a status
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `id` - attachment identifier
+    * `options` - option list
+
+  ## Options
+
+    * `description` - plain-text description of the media for accessibility
+    * `focus` - two floating points between -1.0 and 1.0, comma-delimited
+    * `thumbnail` - path of a custom thumbnail image
+
+  """
+  @spec update_media(Hunter.Client.t(), non_neg_integer, Keyword.t()) :: Hunter.Attachment.t()
+  def update_media(conn, id, options \\ []) do
+    Config.hunter_api().update_media(conn, id, options)
+  end
+
+  @doc """
+  Delete a media attachment that is not currently attached to a status
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `id` - attachment identifier
+
+  """
+  @spec delete_media(Hunter.Client.t(), non_neg_integer) :: boolean
+  def delete_media(conn, id) do
+    Config.hunter_api().delete_media(conn, id)
+  end
 end

--- a/lib/hunter/poll.ex
+++ b/lib/hunter/poll.ex
@@ -20,6 +20,7 @@ defmodule Hunter.Poll do
       (only with user token)
 
   """
+  alias Hunter.Config
 
   @type t :: %__MODULE__{
           id: String.t(),
@@ -47,4 +48,34 @@ defmodule Hunter.Poll do
     :voted,
     :own_votes
   ]
+
+  @doc """
+  Retrieve a poll
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `id` - poll identifier
+
+  """
+  @spec poll(Hunter.Client.t(), non_neg_integer) :: Hunter.Poll.t()
+  def poll(conn, id) do
+    Config.hunter_api().poll(conn, id)
+  end
+
+  @doc """
+  Vote on one or more options in a poll
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `id` - poll identifier
+    * `choices` - list of option indices to vote for (zero-based); multiple
+      choices are only allowed on multiple-choice polls
+
+  """
+  @spec vote(Hunter.Client.t(), non_neg_integer, [non_neg_integer]) :: Hunter.Poll.t()
+  def vote(conn, id, choices) do
+    Config.hunter_api().vote(conn, id, choices)
+  end
 end

--- a/lib/hunter/status.ex
+++ b/lib/hunter/status.ex
@@ -140,9 +140,19 @@ defmodule Hunter.Status do
     * `sensitive` - whether the media of the status is NSFW
     * `spoiler_text` - text to be shown as a warning before the actual content
     * `visibility` - either `direct`, `private`, `unlisted` or `public`
+    * `language` - ISO 639-1 language code for the status
+    * `poll` - map with `options` (list of choices) and `expires_in`
+      (seconds); optional: `multiple`, `hide_totals`
+    * `quoted_status_id` - ID of a status to quote
+    * `scheduled_at` - ISO 8601 datetime (at least 5 minutes ahead) at which
+      the status should be published; the call returns a
+      `Hunter.ScheduledStatus` instead of a `Hunter.Status`
+    * `idempotency_key` - unique string sent as the `Idempotency-Key` header
+      to prevent duplicate submissions
 
   """
-  @spec create_status(Hunter.Client.t(), String.t(), Keyword.t()) :: Hunter.Status.t() | no_return
+  @spec create_status(Hunter.Client.t(), String.t(), Keyword.t()) ::
+          Hunter.Status.t() | Hunter.ScheduledStatus.t() | no_return
   def create_status(conn, status, options \\ []) do
     Config.hunter_api().create_status(conn, status, options)
   end
@@ -159,6 +169,200 @@ defmodule Hunter.Status do
   @spec status(Hunter.Client.t(), status_id) :: Hunter.Status.t()
   def status(conn, id) do
     Config.hunter_api().status(conn, id)
+  end
+
+  @doc """
+  Retrieve multiple statuses by id
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `ids` - list of status identifiers
+
+  """
+  @spec statuses_by_ids(Hunter.Client.t(), [status_id]) :: [Hunter.Status.t()]
+  def statuses_by_ids(conn, ids) do
+    Config.hunter_api().statuses_by_ids(conn, ids)
+  end
+
+  @doc """
+  Edit a status
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `id` - status identifier
+    * `status` - the new text of the status
+    * `options` - option list
+
+  ## Options
+
+    * `spoiler_text` - text to be shown as a warning before the actual content
+    * `sensitive` - whether the media of the status is NSFW
+    * `language` - ISO 639-1 language code for the status
+    * `media_ids` - list of media IDs to attach to the status
+    * `poll` - map with `options` (list of choices) and `expires_in`
+      (seconds); replaces the current poll
+
+  """
+  @spec edit_status(Hunter.Client.t(), status_id, String.t(), Keyword.t()) ::
+          Hunter.Status.t() | no_return
+  def edit_status(conn, id, status, options \\ []) do
+    Config.hunter_api().edit_status(conn, id, status, options)
+  end
+
+  @doc """
+  Retrieve the edit history of a status
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `id` - status identifier
+
+  """
+  @spec status_history(Hunter.Client.t(), status_id) :: [Hunter.StatusEdit.t()]
+  def status_history(conn, id) do
+    Config.hunter_api().status_history(conn, id)
+  end
+
+  @doc """
+  Retrieve the plain-text source of a status, for editing
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `id` - status identifier
+
+  """
+  @spec status_source(Hunter.Client.t(), status_id) :: Hunter.StatusSource.t()
+  def status_source(conn, id) do
+    Config.hunter_api().status_source(conn, id)
+  end
+
+  @doc """
+  Bookmark a status
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `id` - status identifier
+
+  """
+  @spec bookmark(Hunter.Client.t(), status_id) :: Hunter.Status.t()
+  def bookmark(conn, id) do
+    Config.hunter_api().bookmark(conn, id)
+  end
+
+  @doc """
+  Remove a status from bookmarks
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `id` - status identifier
+
+  """
+  @spec unbookmark(Hunter.Client.t(), status_id) :: Hunter.Status.t()
+  def unbookmark(conn, id) do
+    Config.hunter_api().unbookmark(conn, id)
+  end
+
+  @doc """
+  Fetch the user's bookmarked statuses
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `options` - option list
+
+  ## Options
+
+    * `max_id` - get a list of bookmarks with id less than or equal this value
+    * `since_id` - get a list of bookmarks with id greater than this value
+    * `min_id` - get a list of bookmarks with id greater than this value,
+      immediately newer
+    * `limit` - maximum number of bookmarks to get, default: 20, max: 40
+
+  """
+  @spec bookmarks(Hunter.Client.t(), Keyword.t()) :: [Hunter.Status.t()]
+  def bookmarks(conn, options \\ []) do
+    Config.hunter_api().bookmarks(conn, options)
+  end
+
+  @doc """
+  Pin a status to the top of the user's profile
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `id` - status identifier
+
+  """
+  @spec pin(Hunter.Client.t(), status_id) :: Hunter.Status.t()
+  def pin(conn, id) do
+    Config.hunter_api().pin(conn, id)
+  end
+
+  @doc """
+  Unpin a status from the user's profile
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `id` - status identifier
+
+  """
+  @spec unpin(Hunter.Client.t(), status_id) :: Hunter.Status.t()
+  def unpin(conn, id) do
+    Config.hunter_api().unpin(conn, id)
+  end
+
+  @doc """
+  Mute a conversation, so its thread stops generating notifications
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `id` - status identifier
+
+  """
+  @spec mute_conversation(Hunter.Client.t(), status_id) :: Hunter.Status.t()
+  def mute_conversation(conn, id) do
+    Config.hunter_api().mute_conversation(conn, id)
+  end
+
+  @doc """
+  Unmute a conversation
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `id` - status identifier
+
+  """
+  @spec unmute_conversation(Hunter.Client.t(), status_id) :: Hunter.Status.t()
+  def unmute_conversation(conn, id) do
+    Config.hunter_api().unmute_conversation(conn, id)
+  end
+
+  @doc """
+  Translate a status into some language
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `id` - status identifier
+    * `options` - option list
+
+  ## Options
+
+    * `lang` - ISO 639-1 language code the status should be translated into;
+      defaults to the user's current locale
+
+  """
+  @spec translate_status(Hunter.Client.t(), status_id, Keyword.t()) :: Hunter.Translation.t()
+  def translate_status(conn, id, options \\ []) do
+    Config.hunter_api().translate_status(conn, id, options)
   end
 
   @doc """

--- a/lib/hunter/status_edit.ex
+++ b/lib/hunter/status_edit.ex
@@ -1,0 +1,45 @@
+defmodule Hunter.StatusEdit do
+  @moduledoc """
+  StatusEdit entity
+
+  A revision of a `Hunter.Status`, as returned by the status edit history
+  endpoint
+
+  ## Fields
+
+    * `content` - the content of the status at this revision, as HTML
+    * `spoiler_text` - the content of the subject/spoiler at this revision,
+      as HTML
+    * `sensitive` - whether the status was marked sensitive at this revision
+    * `created_at` - when the revision was published
+    * `account` - the `Hunter.Account` that published the status
+    * `poll` - the poll options at this revision, a map with an `options`
+      key (only when the status has a poll)
+    * `media_attachments` - list of `Hunter.Attachment` at this revision
+    * `emojis` - list of `Hunter.Emoji`, custom emoji used in the revision
+
+  """
+
+  @type t :: %__MODULE__{
+          content: String.t(),
+          spoiler_text: String.t(),
+          sensitive: boolean,
+          created_at: String.t(),
+          account: Hunter.Account.t(),
+          poll: map | nil,
+          media_attachments: [Hunter.Attachment.t()],
+          emojis: [Hunter.Emoji.t()]
+        }
+
+  @derive [Poison.Encoder]
+  defstruct [
+    :content,
+    :spoiler_text,
+    :sensitive,
+    :created_at,
+    :account,
+    :poll,
+    :media_attachments,
+    :emojis
+  ]
+end

--- a/lib/hunter/status_source.ex
+++ b/lib/hunter/status_source.ex
@@ -1,0 +1,24 @@
+defmodule Hunter.StatusSource do
+  @moduledoc """
+  StatusSource entity
+
+  The raw, unformatted source of a `Hunter.Status`, as returned by the
+  status source endpoint for use when editing
+
+  ## Fields
+
+    * `id` - the ID of the status
+    * `text` - the plain-text source of the status
+    * `spoiler_text` - the plain-text version of the spoiler warning
+
+  """
+
+  @type t :: %__MODULE__{
+          id: String.t(),
+          text: String.t(),
+          spoiler_text: String.t()
+        }
+
+  @derive [Poison.Encoder]
+  defstruct [:id, :text, :spoiler_text]
+end

--- a/test/fixtures/status_edit.json
+++ b/test/fixtures/status_edit.json
@@ -1,0 +1,23 @@
+{
+  "content": "<p>Testing <a href=\"https://mastodon.example/tags/elixir\">#elixir</a> with @kadaba (edited)</p>",
+  "spoiler_text": "",
+  "sensitive": false,
+  "created_at": "2026-06-30T12:00:00.000Z",
+  "account": {
+    "id": "23634",
+    "username": "milmazz",
+    "acct": "milmazz"
+  },
+  "poll": {
+    "options": [{ "title": "accept" }, { "title": "deny" }]
+  },
+  "media_attachments": [
+    {
+      "id": "22345792",
+      "type": "image",
+      "url": "https://mastodon.example/media/image.png",
+      "preview_url": "https://mastodon.example/media/image_small.png"
+    }
+  ],
+  "emojis": []
+}

--- a/test/fixtures/status_source.json
+++ b/test/fixtures/status_source.json
@@ -1,0 +1,5 @@
+{
+  "id": "103270115826048975",
+  "text": "Testing #elixir with @kadaba",
+  "spoiler_text": ""
+}

--- a/test/hunter/api/transformer_test.exs
+++ b/test/hunter/api/transformer_test.exs
@@ -93,6 +93,24 @@ defmodule Hunter.Api.TransformerTest do
     assert status.quote_approval["current_user"] == "automatic"
   end
 
+  test "decodes a status source" do
+    source = transform("status_source", :status_source)
+
+    assert %Hunter.StatusSource{id: "103270115826048975"} = source
+    assert source.text == "Testing #elixir with @kadaba"
+    assert source.spoiler_text == ""
+  end
+
+  test "decodes a status edit history" do
+    assert [edit] = transform_list("status_edit", :status_edits)
+
+    assert %Hunter.StatusEdit{sensitive: false} = edit
+    assert edit.content =~ "(edited)"
+    assert %Hunter.Account{username: "milmazz"} = edit.account
+    assert [%Hunter.Attachment{id: "22345792"}] = edit.media_attachments
+    assert %{"options" => [%{"title" => "accept"} | _]} = edit.poll
+  end
+
   test "decodes a poll" do
     poll = transform("poll", :poll)
 

--- a/test/hunter/attachment_test.exs
+++ b/test/hunter/attachment_test.exs
@@ -16,4 +16,27 @@ defmodule Hunter.AttachmentTest do
 
     assert %Attachment{type: "image"} = Attachment.upload_media(@conn, "image.png")
   end
+
+  test "returns a media attachment" do
+    expect(Hunter.ApiMock, :media_attachment, fn %Hunter.Client{}, 22_345_792 ->
+      %Attachment{id: "22345792", type: "image", url: "https://example.com/image.png"}
+    end)
+
+    assert %Attachment{id: "22345792"} = Attachment.media_attachment(@conn, 22_345_792)
+  end
+
+  test "updates a media attachment" do
+    expect(Hunter.ApiMock, :update_media, fn %Hunter.Client{}, 22_345_792, opts ->
+      %Attachment{id: "22345792", description: opts[:description]}
+    end)
+
+    assert %Attachment{description: "a cat"} =
+             Attachment.update_media(@conn, 22_345_792, description: "a cat")
+  end
+
+  test "deletes a media attachment" do
+    expect(Hunter.ApiMock, :delete_media, fn %Hunter.Client{}, 22_345_792 -> true end)
+
+    assert Attachment.delete_media(@conn, 22_345_792)
+  end
 end

--- a/test/hunter/poll_test.exs
+++ b/test/hunter/poll_test.exs
@@ -1,0 +1,27 @@
+defmodule Hunter.PollTest do
+  use ExUnit.Case, async: true
+
+  import Mox
+
+  alias Hunter.Poll
+
+  @conn Hunter.Client.new(base_url: "https://example.com", access_token: "123456")
+
+  setup :verify_on_exit!
+
+  test "returns a poll" do
+    expect(Hunter.ApiMock, :poll, fn %Hunter.Client{}, 34_830 ->
+      %Poll{id: "34830", expired: false}
+    end)
+
+    assert %Poll{id: "34830"} = Poll.poll(@conn, 34_830)
+  end
+
+  test "votes on poll options" do
+    expect(Hunter.ApiMock, :vote, fn %Hunter.Client{}, 34_830, [1] ->
+      %Poll{id: "34830", voted: true, own_votes: [1]}
+    end)
+
+    assert %Poll{voted: true, own_votes: [1]} = Poll.vote(@conn, 34_830, [1])
+  end
+end

--- a/test/hunter/status_test.exs
+++ b/test/hunter/status_test.exs
@@ -105,4 +105,93 @@ defmodule Hunter.StatusTest do
 
     assert_raise Hunter.Error, fn -> Status.status(@conn, 0) end
   end
+
+  test "edits a status" do
+    expect(Hunter.ApiMock, :edit_status, fn %Hunter.Client{}, 153_452, "hello again", opts ->
+      %Status{id: "153452", content: "hello again", language: opts[:language]}
+    end)
+
+    assert %Status{content: "hello again", language: "en"} =
+             Status.edit_status(@conn, 153_452, "hello again", language: "en")
+  end
+
+  test "returns the edit history of a status" do
+    expect(Hunter.ApiMock, :status_history, fn %Hunter.Client{}, 153_452 ->
+      [%Hunter.StatusEdit{content: "<p>hello again</p>"}]
+    end)
+
+    assert [%Hunter.StatusEdit{}] = Status.status_history(@conn, 153_452)
+  end
+
+  test "returns the source of a status" do
+    expect(Hunter.ApiMock, :status_source, fn %Hunter.Client{}, 153_452 ->
+      %Hunter.StatusSource{id: "153452", text: "hello again"}
+    end)
+
+    assert %Hunter.StatusSource{text: "hello again"} = Status.status_source(@conn, 153_452)
+  end
+
+  test "bookmarks and unbookmarks a status" do
+    expect(Hunter.ApiMock, :bookmark, fn %Hunter.Client{}, 153_452 ->
+      %Status{id: "153452", bookmarked: true}
+    end)
+
+    expect(Hunter.ApiMock, :unbookmark, fn %Hunter.Client{}, 153_452 ->
+      %Status{id: "153452", bookmarked: false}
+    end)
+
+    assert %Status{bookmarked: true} = Status.bookmark(@conn, 153_452)
+    assert %Status{bookmarked: false} = Status.unbookmark(@conn, 153_452)
+  end
+
+  test "returns bookmarked statuses" do
+    expect(Hunter.ApiMock, :bookmarks, fn %Hunter.Client{}, _opts ->
+      [%Status{id: "153452", bookmarked: true}]
+    end)
+
+    assert [%Status{bookmarked: true}] = Status.bookmarks(@conn)
+  end
+
+  test "pins and unpins a status" do
+    expect(Hunter.ApiMock, :pin, fn %Hunter.Client{}, 153_452 ->
+      %Status{id: "153452", pinned: true}
+    end)
+
+    expect(Hunter.ApiMock, :unpin, fn %Hunter.Client{}, 153_452 ->
+      %Status{id: "153452", pinned: false}
+    end)
+
+    assert %Status{pinned: true} = Status.pin(@conn, 153_452)
+    assert %Status{pinned: false} = Status.unpin(@conn, 153_452)
+  end
+
+  test "mutes and unmutes a conversation" do
+    expect(Hunter.ApiMock, :mute_conversation, fn %Hunter.Client{}, 153_452 ->
+      %Status{id: "153452", muted: true}
+    end)
+
+    expect(Hunter.ApiMock, :unmute_conversation, fn %Hunter.Client{}, 153_452 ->
+      %Status{id: "153452", muted: false}
+    end)
+
+    assert %Status{muted: true} = Status.mute_conversation(@conn, 153_452)
+    assert %Status{muted: false} = Status.unmute_conversation(@conn, 153_452)
+  end
+
+  test "translates a status" do
+    expect(Hunter.ApiMock, :translate_status, fn %Hunter.Client{}, 153_452, [lang: "es"] ->
+      %Hunter.Translation{content: "<p>hola</p>", language: "es"}
+    end)
+
+    assert %Hunter.Translation{language: "es"} =
+             Status.translate_status(@conn, 153_452, lang: "es")
+  end
+
+  test "returns multiple statuses by id" do
+    expect(Hunter.ApiMock, :statuses_by_ids, fn %Hunter.Client{}, [153_452, 153_453] ->
+      [%Status{id: "153452"}, %Status{id: "153453"}]
+    end)
+
+    assert [%Status{}, %Status{}] = Status.statuses_by_ids(@conn, [153_452, 153_453])
+  end
 end

--- a/test/integration/mastodon_test.exs
+++ b/test/integration/mastodon_test.exs
@@ -127,6 +127,113 @@ defmodule Hunter.Integration.MastodonTest do
     Status.destroy_status(conn, id)
   end
 
+  test "edits a status and inspects its source and history", %{conn: conn} do
+    %Status{id: id} = Status.create_status(conn, "first draft #hunterci")
+    on_exit(fn -> destroy_quietly(conn, id) end)
+
+    assert %Status{content: content, edited_at: edited_at} =
+             Status.edit_status(conn, id, "final version #hunterci")
+
+    assert content =~ "final version"
+    assert is_binary(edited_at)
+
+    assert %Hunter.StatusSource{id: ^id, text: "final version #hunterci"} =
+             Status.status_source(conn, id)
+
+    history = Status.status_history(conn, id)
+    assert length(history) == 2
+    assert [%Hunter.StatusEdit{content: first} | _] = history
+    assert first =~ "first draft"
+
+    Status.destroy_status(conn, id)
+  end
+
+  test "bookmarks, pins, and mutes a conversation", %{conn: conn} do
+    %Status{id: id} = Status.create_status(conn, "interactions probe #hunterci")
+    on_exit(fn -> destroy_quietly(conn, id) end)
+
+    assert %Status{bookmarked: true} = Status.bookmark(conn, id)
+    assert Enum.any?(Status.bookmarks(conn), &(&1.id == id))
+    assert %Status{bookmarked: false} = Status.unbookmark(conn, id)
+    refute Enum.any?(Status.bookmarks(conn), &(&1.id == id))
+
+    assert %Status{pinned: true} = Status.pin(conn, id)
+    assert %Status{pinned: false} = Status.unpin(conn, id)
+
+    assert %Status{muted: true} = Status.mute_conversation(conn, id)
+    assert %Status{muted: false} = Status.unmute_conversation(conn, id)
+
+    Status.destroy_status(conn, id)
+  end
+
+  test "poll lifecycle: create, fetch, and vote across accounts", %{conn: conn, conn2: conn2} do
+    status =
+      Status.create_status(conn, "poll probe #hunterci",
+        poll: %{options: ["yes", "no"], expires_in: 3600}
+      )
+
+    assert %Status{id: id, poll: %Hunter.Poll{id: poll_id, expired: false}} = status
+    on_exit(fn -> destroy_quietly(conn, id) end)
+
+    assert %Hunter.Poll{multiple: false, votes_count: 0} = Hunter.Poll.poll(conn2, poll_id)
+
+    assert %Hunter.Poll{voted: true, own_votes: [0], votes_count: 1} =
+             Hunter.Poll.vote(conn2, poll_id, [0])
+
+    Status.destroy_status(conn, id)
+  end
+
+  test "fetches multiple statuses by id", %{conn: conn} do
+    %Status{id: id1} = Status.create_status(conn, "batch one #hunterci")
+    %Status{id: id2} = Status.create_status(conn, "batch two #hunterci")
+    on_exit(fn -> destroy_quietly(conn, id1) end)
+    on_exit(fn -> destroy_quietly(conn, id2) end)
+
+    fetched = Status.statuses_by_ids(conn, [id1, id2])
+    assert Enum.map(fetched, & &1.id) |> Enum.sort() == Enum.sort([id1, id2])
+
+    Status.destroy_status(conn, id1)
+    Status.destroy_status(conn, id2)
+  end
+
+  test "scheduling a status returns a scheduled status; idempotency key deduplicates", %{
+    conn: conn
+  } do
+    scheduled_at =
+      DateTime.utc_now() |> DateTime.add(600, :second) |> DateTime.to_iso8601()
+
+    assert %Hunter.ScheduledStatus{id: _, scheduled_at: _, params: %{"text" => text}} =
+             Status.create_status(conn, "scheduled probe #hunterci", scheduled_at: scheduled_at)
+
+    assert text =~ "scheduled probe"
+
+    key = "hunter-ci-#{System.unique_integer([:positive])}"
+
+    %Status{id: id} =
+      Status.create_status(conn, "idempotent probe #hunterci", idempotency_key: key)
+
+    on_exit(fn -> destroy_quietly(conn, id) end)
+
+    assert %Status{id: ^id} =
+             Status.create_status(conn, "idempotent probe #hunterci", idempotency_key: key)
+
+    Status.destroy_status(conn, id)
+  end
+
+  @tag :tmp_dir
+  test "updates media metadata before attaching", %{conn: conn, tmp_dir: tmp_dir} do
+    path = Path.join(tmp_dir, "hunter-media-update.png")
+    File.write!(path, @png)
+
+    assert %Attachment{id: media_id} = Attachment.upload_media(conn, path)
+
+    assert %Attachment{description: "a tiny test pixel"} =
+             Attachment.update_media(conn, media_id, description: "a tiny test pixel")
+
+    assert %Attachment{id: ^media_id, description: "a tiny test pixel"} =
+             Attachment.media_attachment(conn, media_id)
+  end
+
   test "query parameters take effect server-side", %{conn: conn} do
     %Account{id: account_id} = Account.verify_credentials(conn)
 


### PR DESCRIPTION
Closes #120

Implements the status-parity checklist on top of the #119 entities. Everything follows the existing four-layer pattern (behaviour callback → `HTTPClient` → entity module → `Hunter` facade delegate) and was built test-first.

## Editing (Mastodon 3.5)

- `edit_status/4` — `PUT /api/v1/statuses/:id`
- `status_history/2` — `GET .../history` (new `Hunter.StatusEdit` entity)
- `status_source/2` — `GET .../source` (new `Hunter.StatusSource` entity)

## Interactions

- `bookmark/2`, `unbookmark/2`, `bookmarks/2` (3.1)
- `pin/2`, `unpin/2` (1.6)
- `mute_conversation/2`, `unmute_conversation/2` (1.4.2)
- `translate_status/3` (4.0) — returns `Hunter.Translation`
- `statuses_by_ids/2` — `GET /api/v1/statuses?id[]` (4.3)

## Polls (2.8)

- `Hunter.Poll.poll/2` and `Hunter.Poll.vote/3` (facade: `Hunter.poll/2`, `Hunter.vote/3`)
- `poll` option on `create_status`

## `create_status` upgrades

- `language` and `quoted_status_id` (4.5) options documented and passed through
- `scheduled_at` — the response is decoded as `Hunter.ScheduledStatus` instead of `Hunter.Status`
- `idempotency_key` — sent as the `Idempotency-Key` header, stripped from the body

## Media management

- `media_attachment/2` — `GET /api/v1/media/:id` (poll async-upload processing)
- `update_media/3` — `PUT /api/v1/media/:id` (description/focus/thumbnail)
- `delete_media/2` — `DELETE /api/v1/media/:id` (4.4)

## Testing

- Mox unit tests for every new function; transformer fixture tests for `StatusSource`/`StatusEdit`
- 6 new integration tests against the real CI Mastodon: edit+source+history, bookmark/pin/mute flows, cross-account poll voting, batch fetch, scheduled status + idempotency dedup, media metadata update
- Not integration-covered (CI runs Mastodon **4.3.8**): `delete_media` (needs 4.4), `quoted_status_id` (needs 4.5), `translate_status` (needs a translation backend) — these remain unit-tested only
- `mix format`, `compile --warnings-as-errors`, `credo --strict`, `dialyzer`, full test suite all pass locally: 126 tests + 4 doctests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)
