### PR TITLE
Add Lists support (CRUD, membership, list timeline)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## Unreleased
 
   * Features
+    - Lists support ([#121]): `lists/1`, `list/2`, `create_list/3`,
+      `update_list/3`, `destroy_list/2`, `list_accounts/3`,
+      `add_accounts_to_list/3`, `remove_accounts_from_list/3`,
+      `account_lists/2` (`Hunter.List`) and the `list_timeline/3` timeline
+      (`Hunter.Status`), all exposed on the `Hunter` facade
     - Status parity endpoints ([#120]): `edit_status/4`, `status_history/2`,
       `status_source/2`, `bookmark/2`, `unbookmark/2`, `bookmarks/2`,
       `pin/2`, `unpin/2`, `mute_conversation/2`, `unmute_conversation/2`,
@@ -55,6 +60,7 @@
 
 [#119]: https://github.com/milmazz/hunter/issues/119
 [#120]: https://github.com/milmazz/hunter/issues/120
+[#121]: https://github.com/milmazz/hunter/issues/121
 
 ## v0.6.0
 

--- a/README.md
+++ b/README.md
@@ -292,6 +292,26 @@ iex> Hunter.poll(conn, 34_830)
 %Hunter.Poll{expired: false, votes_count: 1, ...}
 ```
 
+### Lists
+
+```elixir
+iex> list = Hunter.create_list(conn, "Friends", replies_policy: "followed")
+%Hunter.List{id: "12249", title: "Friends", replies_policy: "followed"}
+
+iex> Hunter.add_accounts_to_list(conn, list.id, [8039])
+iex> Hunter.list_accounts(conn, list.id)
+[%Hunter.Account{id: "8039", ...}]
+
+iex> Hunter.list_timeline(conn, list.id)
+[%Hunter.Status{...}]
+
+iex> Hunter.destroy_list(conn, list.id)
+```
+
+Accounts must be followed before they can be added to a list. See also
+`Hunter.lists/1`, `Hunter.list/2`, `Hunter.update_list/3`,
+`Hunter.remove_accounts_from_list/3`, and `Hunter.account_lists/2`.
+
 ### Get instance information
 
 ```elixir

--- a/lib/hunter.ex
+++ b/lib/hunter.ex
@@ -850,6 +850,160 @@ defmodule Hunter do
   defdelegate hashtag_timeline(conn, hashtag, options \\ []), to: Hunter.Status
 
   @doc """
+  Retrieve statuses from the given list's timeline
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `list_id` - list identifier
+    * `options` - option list
+
+  ## Options
+
+    * `max_id` - get a list of timelines with id less than or equal this value
+    * `since_id` - get a list of timelines with id greater than this value
+    * `limit` - maximum number of statuses on the requested timeline to get, default: 20, max: 40
+
+  """
+  @spec list_timeline(Hunter.Client.t(), non_neg_integer, Keyword.t()) :: [Hunter.Status.t()]
+  defdelegate list_timeline(conn, list_id, options \\ []), to: Hunter.Status
+
+  @doc """
+  Retrieve all lists the user owns
+
+  ## Parameters
+
+    * `conn` - connection credentials
+
+  """
+  @spec lists(Hunter.Client.t()) :: [Hunter.List.t()]
+  defdelegate lists(conn), to: Hunter.List
+
+  @doc """
+  Retrieve a list
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `id` - list identifier
+
+  """
+  @spec list(Hunter.Client.t(), non_neg_integer) :: Hunter.List.t()
+  defdelegate list(conn, id), to: Hunter.List
+
+  @doc """
+  Create a new list
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `title` - the title of the list
+    * `options` - option list
+
+  ## Options
+
+    * `replies_policy` - which replies should be shown in the list, one of:
+      `followed`, `list`, `none`; default: `list`
+    * `exclusive` - whether members of the list are removed from the home
+      timeline
+
+  """
+  @spec create_list(Hunter.Client.t(), String.t(), Keyword.t()) :: Hunter.List.t()
+  defdelegate create_list(conn, title, options \\ []), to: Hunter.List
+
+  @doc """
+  Update a list
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `id` - list identifier
+    * `options` - option list
+
+  ## Options
+
+    * `title` - the new title of the list
+    * `replies_policy` - which replies should be shown in the list, one of:
+      `followed`, `list`, `none`
+    * `exclusive` - whether members of the list are removed from the home
+      timeline
+
+  """
+  @spec update_list(Hunter.Client.t(), non_neg_integer, Keyword.t()) :: Hunter.List.t()
+  defdelegate update_list(conn, id, options), to: Hunter.List
+
+  @doc """
+  Delete a list
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `id` - list identifier
+
+  """
+  @spec destroy_list(Hunter.Client.t(), non_neg_integer) :: boolean
+  defdelegate destroy_list(conn, id), to: Hunter.List
+
+  @doc """
+  Retrieve the accounts in a list
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `id` - list identifier
+    * `options` - option list
+
+  ## Options
+
+    * `max_id` - get a list of accounts with id less than or equal this value
+    * `since_id` - get a list of accounts with id greater than this value
+    * `limit` - maximum number of accounts to get, default: 40; set to 0 to
+      get all accounts in the list
+
+  """
+  @spec list_accounts(Hunter.Client.t(), non_neg_integer, Keyword.t()) :: [Hunter.Account.t()]
+  defdelegate list_accounts(conn, id, options \\ []), to: Hunter.List
+
+  @doc """
+  Add accounts to a list; the user must be following each of them
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `id` - list identifier
+    * `account_ids` - account identifiers to add
+
+  """
+  @spec add_accounts_to_list(Hunter.Client.t(), non_neg_integer, [non_neg_integer]) :: boolean
+  defdelegate add_accounts_to_list(conn, id, account_ids), to: Hunter.List
+
+  @doc """
+  Remove accounts from a list
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `id` - list identifier
+    * `account_ids` - account identifiers to remove
+
+  """
+  @spec remove_accounts_from_list(Hunter.Client.t(), non_neg_integer, [non_neg_integer]) ::
+          boolean
+  defdelegate remove_accounts_from_list(conn, id, account_ids), to: Hunter.List
+
+  @doc """
+  Retrieve the user's lists that contain a given account
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `account_id` - account identifier
+
+  """
+  @spec account_lists(Hunter.Client.t(), non_neg_integer) :: [Hunter.List.t()]
+  defdelegate account_lists(conn, account_id), to: Hunter.List
+
+  @doc """
   Retrieve instance information
 
   ## Parameters

--- a/lib/hunter/api.ex
+++ b/lib/hunter/api.ex
@@ -774,6 +774,166 @@ defmodule Hunter.Api do
   @callback public_timeline(conn :: Hunter.Client.t(), options :: map) :: [Hunter.Status.t()]
 
   @doc """
+  Retrieve statuses from the given list's timeline
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `list_id` - list identifier
+    * `options` - option list
+
+  ## Options
+
+    * `max_id` - get a list of timelines with id less than or equal this value
+    * `since_id` - get a list of timelines with id greater than this value
+    * `limit` - maximum number of statuses on the requested timeline to get, default: 20, max: 40
+
+  """
+  @callback list_timeline(conn :: Hunter.Client.t(), list_id :: non_neg_integer, options :: map) ::
+              [Hunter.Status.t()]
+
+  @doc """
+  Retrieve all lists the user owns
+
+  ## Parameters
+
+    * `conn` - connection credentials
+
+  """
+  @callback lists(conn :: Hunter.Client.t()) :: [Hunter.List.t()]
+
+  @doc """
+  Retrieve a list
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `id` - list identifier
+
+  """
+  @callback list(conn :: Hunter.Client.t(), id :: non_neg_integer) :: Hunter.List.t()
+
+  @doc """
+  Create a new list
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `title` - the title of the list
+    * `options` - option list
+
+  ## Options
+
+    * `replies_policy` - which replies should be shown in the list, one of:
+      `followed`, `list`, `none`; default: `list`
+    * `exclusive` - whether members of the list are removed from the home
+      timeline
+
+  """
+  @callback create_list(conn :: Hunter.Client.t(), title :: String.t(), options :: Keyword.t()) ::
+              Hunter.List.t()
+
+  @doc """
+  Update a list
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `id` - list identifier
+    * `options` - option list
+
+  ## Options
+
+    * `title` - the new title of the list
+    * `replies_policy` - which replies should be shown in the list, one of:
+      `followed`, `list`, `none`
+    * `exclusive` - whether members of the list are removed from the home
+      timeline
+
+  """
+  @callback update_list(conn :: Hunter.Client.t(), id :: non_neg_integer, options :: Keyword.t()) ::
+              Hunter.List.t()
+
+  @doc """
+  Delete a list
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `id` - list identifier
+
+  """
+  @callback destroy_list(conn :: Hunter.Client.t(), id :: non_neg_integer) :: boolean
+
+  @doc """
+  Retrieve the accounts in a list
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `id` - list identifier
+    * `options` - option list
+
+  ## Options
+
+    * `max_id` - get a list of accounts with id less than or equal this value
+    * `since_id` - get a list of accounts with id greater than this value
+    * `limit` - maximum number of accounts to get, default: 40; set to 0 to
+      get all accounts in the list
+
+  """
+  @callback list_accounts(
+              conn :: Hunter.Client.t(),
+              id :: non_neg_integer,
+              options :: Keyword.t()
+            ) :: [Hunter.Account.t()]
+
+  @doc """
+  Add accounts to a list; the user must be following each of them
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `id` - list identifier
+    * `account_ids` - account identifiers to add
+
+  """
+  @callback add_accounts_to_list(
+              conn :: Hunter.Client.t(),
+              id :: non_neg_integer,
+              account_ids :: [non_neg_integer]
+            ) :: boolean
+
+  @doc """
+  Remove accounts from a list
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `id` - list identifier
+    * `account_ids` - account identifiers to remove
+
+  """
+  @callback remove_accounts_from_list(
+              conn :: Hunter.Client.t(),
+              id :: non_neg_integer,
+              account_ids :: [non_neg_integer]
+            ) :: boolean
+
+  @doc """
+  Retrieve the user's lists that contain a given account
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `account_id` - account identifier
+
+  """
+  @callback account_lists(conn :: Hunter.Client.t(), account_id :: non_neg_integer) :: [
+              Hunter.List.t()
+            ]
+
+  @doc """
   Retrieve statuses from a hashtag
 
   ## Parameters

--- a/lib/hunter/api/http_client.ex
+++ b/lib/hunter/api/http_client.ex
@@ -325,6 +325,66 @@ defmodule Hunter.Api.HTTPClient do
     retrieve_timeline(conn, "/api/v1/timelines/tag/#{hashtag}", options)
   end
 
+  def list_timeline(conn, list_id, options) do
+    retrieve_timeline(conn, "/api/v1/timelines/list/#{list_id}", options)
+  end
+
+  def lists(conn) do
+    "/api/v1/lists"
+    |> process_url(conn)
+    |> request!(:lists, :get, [], conn)
+  end
+
+  def list(conn, id) do
+    "/api/v1/lists/#{id}"
+    |> process_url(conn)
+    |> request!(:list, :get, [], conn)
+  end
+
+  def create_list(conn, title, options) do
+    body = options |> Keyword.put(:title, title) |> Map.new()
+
+    "/api/v1/lists"
+    |> process_url(conn)
+    |> request!(:list, :post, body, conn)
+  end
+
+  def update_list(conn, id, options) do
+    "/api/v1/lists/#{id}"
+    |> process_url(conn)
+    |> request!(:list, :put, Map.new(options), conn)
+  end
+
+  def destroy_list(conn, id) do
+    "/api/v1/lists/#{id}"
+    |> process_url(conn)
+    |> request!(nil, :delete, [], conn)
+  end
+
+  def list_accounts(conn, id, options) do
+    "/api/v1/lists/#{id}/accounts"
+    |> process_url(conn)
+    |> request!(:accounts, :get, options, conn)
+  end
+
+  def add_accounts_to_list(conn, id, account_ids) do
+    "/api/v1/lists/#{id}/accounts"
+    |> process_url(conn)
+    |> request!(nil, :post, %{account_ids: account_ids}, conn)
+  end
+
+  def remove_accounts_from_list(conn, id, account_ids) do
+    "/api/v1/lists/#{id}/accounts"
+    |> process_url(conn)
+    |> request!(nil, :delete, %{account_ids: account_ids}, conn)
+  end
+
+  def account_lists(conn, account_id) do
+    "/api/v1/accounts/#{account_id}/lists"
+    |> process_url(conn)
+    |> request!(:lists, :get, [], conn)
+  end
+
   defp retrieve_timeline(conn, endpoint, options) do
     endpoint
     |> process_url(conn)

--- a/lib/hunter/list.ex
+++ b/lib/hunter/list.ex
@@ -14,6 +14,7 @@ defmodule Hunter.List do
       timeline
 
   """
+  alias Hunter.Config
 
   @type t :: %__MODULE__{
           id: String.t(),
@@ -24,4 +25,157 @@ defmodule Hunter.List do
 
   @derive [Poison.Encoder]
   defstruct [:id, :title, :replies_policy, :exclusive]
+
+  @doc """
+  Retrieve all lists the user owns
+
+  ## Parameters
+
+    * `conn` - connection credentials
+
+  """
+  @spec lists(Hunter.Client.t()) :: [Hunter.List.t()]
+  def lists(conn) do
+    Config.hunter_api().lists(conn)
+  end
+
+  @doc """
+  Retrieve a list
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `id` - list identifier
+
+  """
+  @spec list(Hunter.Client.t(), non_neg_integer) :: Hunter.List.t()
+  def list(conn, id) do
+    Config.hunter_api().list(conn, id)
+  end
+
+  @doc """
+  Create a new list
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `title` - the title of the list
+    * `options` - option list
+
+  ## Options
+
+    * `replies_policy` - which replies should be shown in the list, one of:
+      `followed`, `list`, `none`; default: `list`
+    * `exclusive` - whether members of the list are removed from the home
+      timeline
+
+  """
+  @spec create_list(Hunter.Client.t(), String.t(), Keyword.t()) :: Hunter.List.t()
+  def create_list(conn, title, options \\ []) do
+    Config.hunter_api().create_list(conn, title, options)
+  end
+
+  @doc """
+  Update a list
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `id` - list identifier
+    * `options` - option list
+
+  ## Options
+
+    * `title` - the new title of the list
+    * `replies_policy` - which replies should be shown in the list, one of:
+      `followed`, `list`, `none`
+    * `exclusive` - whether members of the list are removed from the home
+      timeline
+
+  """
+  @spec update_list(Hunter.Client.t(), non_neg_integer, Keyword.t()) :: Hunter.List.t()
+  def update_list(conn, id, options) do
+    Config.hunter_api().update_list(conn, id, options)
+  end
+
+  @doc """
+  Delete a list
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `id` - list identifier
+
+  """
+  @spec destroy_list(Hunter.Client.t(), non_neg_integer) :: boolean
+  def destroy_list(conn, id) do
+    Config.hunter_api().destroy_list(conn, id)
+  end
+
+  @doc """
+  Retrieve the accounts in a list
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `id` - list identifier
+    * `options` - option list
+
+  ## Options
+
+    * `max_id` - get a list of accounts with id less than or equal this value
+    * `since_id` - get a list of accounts with id greater than this value
+    * `limit` - maximum number of accounts to get, default: 40; set to 0 to
+      get all accounts in the list
+
+  """
+  @spec list_accounts(Hunter.Client.t(), non_neg_integer, Keyword.t()) :: [Hunter.Account.t()]
+  def list_accounts(conn, id, options \\ []) do
+    Config.hunter_api().list_accounts(conn, id, options)
+  end
+
+  @doc """
+  Add accounts to a list; the user must be following each of them
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `id` - list identifier
+    * `account_ids` - account identifiers to add
+
+  """
+  @spec add_accounts_to_list(Hunter.Client.t(), non_neg_integer, [non_neg_integer]) :: boolean
+  def add_accounts_to_list(conn, id, account_ids) do
+    Config.hunter_api().add_accounts_to_list(conn, id, account_ids)
+  end
+
+  @doc """
+  Remove accounts from a list
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `id` - list identifier
+    * `account_ids` - account identifiers to remove
+
+  """
+  @spec remove_accounts_from_list(Hunter.Client.t(), non_neg_integer, [non_neg_integer]) ::
+          boolean
+  def remove_accounts_from_list(conn, id, account_ids) do
+    Config.hunter_api().remove_accounts_from_list(conn, id, account_ids)
+  end
+
+  @doc """
+  Retrieve the user's lists that contain a given account
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `account_id` - account identifier
+
+  """
+  @spec account_lists(Hunter.Client.t(), non_neg_integer) :: [Hunter.List.t()]
+  def account_lists(conn, account_id) do
+    Config.hunter_api().account_lists(conn, account_id)
+  end
 end

--- a/lib/hunter/status.ex
+++ b/lib/hunter/status.ex
@@ -540,4 +540,25 @@ defmodule Hunter.Status do
   def hashtag_timeline(conn, hashtag, options \\ []) do
     Config.hunter_api().hashtag_timeline(conn, hashtag, Map.new(options))
   end
+
+  @doc """
+  Retrieve statuses from the given list's timeline
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `list_id` - list identifier
+    * `options` - option list
+
+  ## Options
+
+    * `max_id` - get a list of timelines with id less than or equal this value
+    * `since_id` - get a list of timelines with id greater than this value
+    * `limit` - maximum number of statuses on the requested timeline to get, default: 20, max: 40
+
+  """
+  @spec list_timeline(Hunter.Client.t(), non_neg_integer, Keyword.t()) :: [Hunter.Status.t()]
+  def list_timeline(conn, list_id, options \\ []) do
+    Config.hunter_api().list_timeline(conn, list_id, Map.new(options))
+  end
 end

--- a/test/hunter/list_test.exs
+++ b/test/hunter/list_test.exs
@@ -1,0 +1,83 @@
+defmodule Hunter.ListTest do
+  use ExUnit.Case, async: true
+
+  import Mox
+
+  alias Hunter.List
+
+  @conn Hunter.Client.new(base_url: "https://example.com", access_token: "123456")
+
+  setup :verify_on_exit!
+
+  test "returns all lists the user owns" do
+    expect(Hunter.ApiMock, :lists, fn %Hunter.Client{} ->
+      [%List{id: "12249", title: "Friends"}]
+    end)
+
+    assert [%List{title: "Friends"}] = List.lists(@conn)
+  end
+
+  test "returns a single list" do
+    expect(Hunter.ApiMock, :list, fn %Hunter.Client{}, 12_249 ->
+      %List{id: "12249", title: "Friends"}
+    end)
+
+    assert %List{id: "12249"} = List.list(@conn, 12_249)
+  end
+
+  test "creates a list" do
+    expect(Hunter.ApiMock, :create_list, fn %Hunter.Client{}, "Friends", opts ->
+      %List{id: "12249", title: "Friends", replies_policy: opts[:replies_policy]}
+    end)
+
+    assert %List{title: "Friends", replies_policy: "followed"} =
+             List.create_list(@conn, "Friends", replies_policy: "followed")
+  end
+
+  test "updates a list" do
+    expect(Hunter.ApiMock, :update_list, fn %Hunter.Client{}, 12_249, opts ->
+      %List{id: "12249", title: opts[:title], exclusive: opts[:exclusive]}
+    end)
+
+    assert %List{title: "Close friends", exclusive: true} =
+             List.update_list(@conn, 12_249, title: "Close friends", exclusive: true)
+  end
+
+  test "destroys a list" do
+    expect(Hunter.ApiMock, :destroy_list, fn %Hunter.Client{}, 12_249 -> true end)
+
+    assert List.destroy_list(@conn, 12_249)
+  end
+
+  test "returns accounts in a list" do
+    expect(Hunter.ApiMock, :list_accounts, fn %Hunter.Client{}, 12_249, _opts ->
+      [%Hunter.Account{id: "8039", username: "kadaba"}]
+    end)
+
+    assert [%Hunter.Account{username: "kadaba"}] = List.list_accounts(@conn, 12_249)
+  end
+
+  test "adds accounts to a list" do
+    expect(Hunter.ApiMock, :add_accounts_to_list, fn %Hunter.Client{}, 12_249, [8039] ->
+      true
+    end)
+
+    assert List.add_accounts_to_list(@conn, 12_249, [8039])
+  end
+
+  test "removes accounts from a list" do
+    expect(Hunter.ApiMock, :remove_accounts_from_list, fn %Hunter.Client{}, 12_249, [8039] ->
+      true
+    end)
+
+    assert List.remove_accounts_from_list(@conn, 12_249, [8039])
+  end
+
+  test "returns lists containing a given account" do
+    expect(Hunter.ApiMock, :account_lists, fn %Hunter.Client{}, 8039 ->
+      [%List{id: "12249", title: "Friends"}]
+    end)
+
+    assert [%List{title: "Friends"}] = List.account_lists(@conn, 8039)
+  end
+end

--- a/test/hunter/status_test.exs
+++ b/test/hunter/status_test.exs
@@ -90,6 +90,14 @@ defmodule Hunter.StatusTest do
     assert [%Status{}] = Status.statuses(@conn, 23_634)
   end
 
+  test "returns a list timeline" do
+    expect(Hunter.ApiMock, :list_timeline, fn %Hunter.Client{}, 12_249, %{} ->
+      [%Status{id: "153452"}]
+    end)
+
+    assert [%Status{}] = Status.list_timeline(@conn, 12_249)
+  end
+
   test "returns a hashtag timeline" do
     expect(Hunter.ApiMock, :hashtag_timeline, fn %Hunter.Client{}, "elixir", %{} ->
       [%Status{id: "153452"}]

--- a/test/integration/mastodon_test.exs
+++ b/test/integration/mastodon_test.exs
@@ -234,6 +234,47 @@ defmodule Hunter.Integration.MastodonTest do
              Attachment.media_attachment(conn, media_id)
   end
 
+  test "list lifecycle: create, membership, timeline, update, destroy", %{
+    conn: conn,
+    conn2: conn2
+  } do
+    %Account{id: id2} = Account.verify_credentials(conn2)
+
+    # membership requires following the account first
+    assert %Relationship{following: true} = Relationship.follow(conn, id2)
+    on_exit(fn -> unfollow_quietly(conn, id2) end)
+
+    assert %Hunter.List{id: list_id, title: "hunter ci"} =
+             Hunter.List.create_list(conn, "hunter ci", replies_policy: "followed")
+
+    on_exit(fn -> destroy_list_quietly(conn, list_id) end)
+
+    assert Hunter.List.add_accounts_to_list(conn, list_id, [id2])
+    assert [%Account{id: ^id2}] = Hunter.List.list_accounts(conn, list_id)
+    assert Enum.any?(Hunter.List.account_lists(conn, id2), &(&1.id == list_id))
+    assert Enum.any?(Hunter.List.lists(conn), &(&1.id == list_id))
+
+    %Status{id: status_id} = Status.create_status(conn2, "list timeline probe #hunterci")
+    on_exit(fn -> destroy_quietly(conn2, status_id) end)
+
+    eventually(fn ->
+      timeline = Status.list_timeline(conn, list_id)
+      assert Enum.any?(timeline, &(&1.id == status_id))
+    end)
+
+    assert %Hunter.List{title: "hunter ci renamed"} =
+             Hunter.List.update_list(conn, list_id, title: "hunter ci renamed")
+
+    assert Hunter.List.remove_accounts_from_list(conn, list_id, [id2])
+    assert [] = Hunter.List.list_accounts(conn, list_id)
+
+    assert Hunter.List.destroy_list(conn, list_id)
+    assert_raise Hunter.Error, fn -> Hunter.List.list(conn, list_id) end
+
+    Status.destroy_status(conn2, status_id)
+    Relationship.unfollow(conn, id2)
+  end
+
   test "query parameters take effect server-side", %{conn: conn} do
     %Account{id: account_id} = Account.verify_credentials(conn)
 
@@ -335,6 +376,13 @@ defmodule Hunter.Integration.MastodonTest do
 
   defp unfollow_quietly(conn, id) do
     Relationship.unfollow(conn, id)
+    :ok
+  rescue
+    Hunter.Error -> :ok
+  end
+
+  defp destroy_list_quietly(conn, id) do
+    Hunter.List.destroy_list(conn, id)
     :ok
   rescue
     Hunter.Error -> :ok


### PR DESCRIPTION
Closes #121

Follows the four-layer pattern, built test-first on top of the #119 `Hunter.List` entity:

- **CRUD** (`Hunter.List`): `lists/1`, `list/2`, `create_list/3` (`replies_policy`, `exclusive` options), `update_list/3`, `destroy_list/2`
- **Membership**: `list_accounts/3`, `add_accounts_to_list/3`, `remove_accounts_from_list/3`, `account_lists/2` (lists containing a given account)
- **Timeline** (`Hunter.Status`): `list_timeline/3`
- All exposed on the `Hunter` facade; README gained a Lists section

## Testing

- Mox unit tests for every function (10 new tests)
- One end-to-end integration test against the real CI Mastodon: follow → create list → add member → membership queries from both directions → member's status appears on the list timeline → rename → remove member → destroy (with 404 confirmation)
- `mix format`, `compile --warnings-as-errors`, `credo --strict`, `dialyzer`, full suite pass locally: 136 tests + 4 doctests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)