### PR TITLE
Typespec honesty: string entity ids, true booleans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 ## Unreleased
 
   * Breaking changes
+    - Typespec honesty ([#116]): entity `id` fields are now typed
+      `String.t()` — what Mastodon has returned since 2.0 and what the
+      structs actually held at runtime; id parameters accept
+      `String.t() | non_neg_integer` as before
+    - Fire-and-forget endpoints (`destroy_status`, `destroy_list`,
+      `delete_media`, `clear_notification(s)`, `block_domain`,
+      `unblock_domain`, `add_accounts_to_list`,
+      `remove_accounts_from_list`) now return `true` as their `boolean`
+      specs always promised, instead of leaking the decoded response
+      body ([#116])
     - Require Elixir 1.16+ (media uploads stream the file in raw byte
       chunks, which needs the `File.stream!(path, bytes)` argument order
       introduced in 1.16); the 1.15 floor existed only for httpoison's
@@ -77,6 +87,7 @@
 [#120]: https://github.com/milmazz/hunter/issues/120
 [#121]: https://github.com/milmazz/hunter/issues/121
 [#103]: https://github.com/milmazz/hunter/issues/103
+[#116]: https://github.com/milmazz/hunter/issues/116
 
 ## v0.6.0
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ We use [SemVer](http://semver.org/) for versioning. For the versions available, 
 iex> app = Hunter.create_app("hunter", "urn:ietf:wg:oauth:2.0:oob", ["read", "write", "follow"], nil, [save?: true, api_base_url: "https://example.com"])
 %Hunter.Application{client_id: "1234567890",
  client_secret: "1234567890",
- id: 1234}
+ id: "1234"}
 ```
 
 You can also load the application's saved credentials:
@@ -54,7 +54,7 @@ You can also load the application's saved credentials:
 iex> app = Hunter.Application.load_credentials("hunter")
 %Hunter.Application{client_id: "1234567890",
  client_secret: "1234567890",
- id: 1234}
+ id: "1234"}
 ```
 
 ### Acquire an access token
@@ -96,7 +96,7 @@ iex> Hunter.verify_credentials(conn)
  avatar: "https://social.lou.lt/avatars/original/missing.png",
  created_at: "2017-04-06T17:43:55.325Z", display_name: "Milton Mazzarri",
  followers_count: 2, following_count: 3,
- header: "https://social.lou.lt/headers/original/missing.png", id: 8039,
+ header: "https://social.lou.lt/headers/original/missing.png", id: "8039",
  locked: false, note: "", statuses_count: 1,
  url: "https://social.lou.lt/@milmazz", username: "milmazz"}
 ```
@@ -111,7 +111,7 @@ iex> Hunter.account(conn, 8039)
  avatar: "https://social.lou.lt/avatars/original/missing.png",
  created_at: "2017-04-06T17:43:55.325Z", display_name: "Milton Mazzarri",
  followers_count: 2, following_count: 3,
- header: "https://social.lou.lt/headers/original/missing.png", id: 8039,
+ header: "https://social.lou.lt/headers/original/missing.png", id: "8039",
  locked: false, note: "", statuses_count: 1,
  url: "https://social.lou.lt/@milmazz", username: "milmazz"}
 ```
@@ -127,7 +127,7 @@ iex> Hunter.followers(conn, 8039)
   created_at: "2017-04-06T20:07:57.119Z", display_name: "Carlos Gustavo Ruiz",
   followers_count: 2, following_count: 2,
   header: "https://social.lou.lt/system/accounts/headers/000/008/518/original/394f31473de7c64a.png?1491509277",
-  id: 8518, locked: false,
+  id: "8518", locked: false,
   note: "Programmer, Pythonista, Web Creature, Blogger, C++ and Haskell Fan. Never stop learning, because life never stops teaching.",
   statuses_count: 1, url: "https://mastodon.club/@atmantree",
   username: "atmantree"},
@@ -147,7 +147,7 @@ iex> Hunter.following(conn, 8039)
   display_name: "Sebastián Ramírez Magrí", followers_count: 2,
   following_count: 1,
   header: "https://social.lou.lt/system/accounts/headers/000/007/899/original/missing.png?1491498458",
-  id: 7899, locked: false, note: "", statuses_count: 2,
+  id: "7899", locked: false, note: "", statuses_count: 2,
   url: "https://mastodon.cloud/@sebasmagri", username: "sebasmagri"},
   ...]
  ```
@@ -175,13 +175,13 @@ iex> Hunter.statuses(conn, 8039)
    avatar: "https://social.lou.lt/avatars/original/missing.png",
    created_at: "2017-04-06T17:43:55.325Z", display_name: "Milton Mazzarri",
    followers_count: 4, following_count: 4,
-   header: "https://social.lou.lt/headers/original/missing.png", id: 8039,
+   header: "https://social.lou.lt/headers/original/missing.png", id: "8039",
    locked: false, note: "", statuses_count: 2,
    url: "https://social.lou.lt/@milmazz", username: "milmazz"},
   application: %Hunter.Application{client_id: nil, client_secret: nil, id: nil},
   content: "<p>Hunter is a Elixir client for Mastodon: <a href=\"https://github.com/milmazz/hunter\" rel=\"nofollow noopener\" target=\"_blank\"><span class=\"invisible\">https://</span><span class=\"\">github.com/milmazz/hunter</span><span class=\"invisible\"></span></a> <a href=\"https://social.lou.lt/tags/myelixirstatus\" class=\"mention hashtag\">#<span>myelixirstatus</span></a></p>",
   created_at: "2017-04-08T04:41:38.643Z", favourited: nil, favourites_count: 1,
-  id: 118635, in_reply_to_account_id: nil, in_reply_to_id: nil,
+  id: "118635", in_reply_to_account_id: nil, in_reply_to_id: nil,
   media_attachments: [], mentions: [], reblog: nil, reblogged: nil,
   reblogs_count: 0, sensitive: nil, spoiler_text: "",
   tags: [%Hunter.Tag{name: "myelixirstatus",
@@ -212,14 +212,14 @@ iex> Hunter.favourite(conn, 442)
   created_at: "2017-04-03T13:50:06.485Z", display_name: "FriendlyPootis 🚉",
   followers_count: 62, following_count: 53,
   header: "https://social.lou.lt/system/accounts/headers/000/000/034/original/b009ddb5a8ce41c1.jpg?1491228302",
-  id: 34, locked: false,
+  id: "34", locked: false,
   note: "fermé comme un carré, Vladimir Pootin sur YT (<a href=\"https://www.youtube.com/VladimirPootin\" rel=\"nofollow noopener\" target=\"_blank\"><span class=\"invisible\">https://www.</span><span class=\"\">youtube.com/VladimirPootin</span><span class=\"invisible\"></span></a>)",
   statuses_count: 253, url: "https://social.lou.lt/@FriendlyPootis",
   username: "FriendlyPootis"},
  application: %Hunter.Application{client_id: nil, client_secret: nil, id: nil},
  content: "<p>les gens pensez à migrer d&apos;instance pour en aller sur une moins chargée tant que vous pouvez, plus vous attendrez plus vous aurez la flemme</p>",
  created_at: "2017-04-03T16:22:04.286Z", favourited: true, favourites_count: 5,
- id: 442, in_reply_to_account_id: nil, in_reply_to_id: nil,
+ id: "442", in_reply_to_account_id: nil, in_reply_to_id: nil,
  media_attachments: [], mentions: [], reblog: nil, reblogged: false,
  reblogs_count: 4, sensitive: false, spoiler_text: "", tags: [],
  uri: "tag:social.lou.lt,2017-04-03:objectId=442:objectType=Status",
@@ -233,14 +233,14 @@ iex> Hunter.unfavourite(conn, 442)
   created_at: "2017-04-03T13:50:06.485Z", display_name: "FriendlyPootis 🚉",
   followers_count: 62, following_count: 53,
   header: "https://social.lou.lt/system/accounts/headers/000/000/034/original/b009ddb5a8ce41c1.jpg?1491228302",
-  id: 34, locked: false,
+  id: "34", locked: false,
   note: "fermé comme un carré, Vladimir Pootin sur YT (<a href=\"https://www.youtube.com/VladimirPootin\" rel=\"nofollow noopener\" target=\"_blank\"><span class=\"invisible\">https://www.</span><span class=\"\">youtube.com/VladimirPootin</span><span class=\"invisible\"></span></a>)",
   statuses_count: 253, url: "https://social.lou.lt/@FriendlyPootis",
   username: "FriendlyPootis"},
  application: %Hunter.Application{client_id: nil, client_secret: nil, id: nil},
  content: "<p>les gens pensez à migrer d&apos;instance pour en aller sur une moins chargée tant que vous pouvez, plus vous attendrez plus vous aurez la flemme</p>",
  created_at: "2017-04-03T16:22:04.286Z", favourited: true, favourites_count: 5,
- id: 442, in_reply_to_account_id: nil, in_reply_to_id: nil,
+ id: "442", in_reply_to_account_id: nil, in_reply_to_id: nil,
  media_attachments: [], mentions: [], reblog: nil, reblogged: false,
  reblogs_count: 4, sensitive: false, spoiler_text: "", tags: [],
  uri: "tag:social.lou.lt,2017-04-03:objectId=442:objectType=Status",
@@ -330,10 +330,10 @@ iex> Hunter.notifications(conn)
    created_at: "2017-04-06T13:44:18.281Z", display_name: "Papers We Love",
    followers_count: 1, following_count: 1,
    header: "https://social.lou.lt/system/accounts/headers/000/007/126/original/missing.png?1491486258",
-   id: 7126, locked: false,
+   id: "7126", locked: false,
    note: "Building Bridges Between Academia and Industry\n\n<a href=\"http://paperswelove.org\" rel=\"nofollow noopener\"><span class=\"invisible\">http://</span><span class=\"\">paperswelove.org</span><span class=\"invisible\"></span></a>\n<a href=\"http://pwlconf.org\" rel=\"nofollow noopener noopener\"><span class=\"invisible\">http://</span><span class=\"\">pwlconf.org</span><span class=\"invisible\"></span></a>",
    statuses_count: 8, url: "https://mstdn.io/@paperswelove",
-   username: "paperswelove"}, created_at: "2017-04-08T12:15:53.467Z", id: 17476,
+   username: "paperswelove"}, created_at: "2017-04-08T12:15:53.467Z", id: "17476",
   status: nil, type: "follow"},
  ...
 ]
@@ -350,10 +350,10 @@ iex> Hunter.notification(conn, 17476)
   created_at: "2017-04-06T13:44:18.281Z", display_name: "Papers We Love",
   followers_count: 1, following_count: 1,
   header: "https://social.lou.lt/system/accounts/headers/000/007/126/original/missing.png?1491486258",
-  id: 7126, locked: false,
+  id: "7126", locked: false,
   note: "Building Bridges Between Academia and Industry\n\n<a href=\"http://paperswelove.org\" rel=\"nofollow noopener\"><span class=\"invisible\">http://</span><span class=\"\">paperswelove.org</span><span class=\"invisible\"></span></a>\n<a href=\"http://pwlconf.org\" rel=\"nofollow noopener noopener\"><span class=\"invisible\">http://</span><span class=\"\">pwlconf.org</span><span class=\"invisible\"></span></a>",
   statuses_count: 8, url: "https://mstdn.io/@paperswelove",
-  username: "paperswelove"}, created_at: "2017-04-08T12:15:53.467Z", id: 17476,
+  username: "paperswelove"}, created_at: "2017-04-08T12:15:53.467Z", id: "17476",
  status: nil, type: "follow"}
 ```
 
@@ -406,14 +406,14 @@ iex> Hunter.hashtag_timeline(conn, "paperswelove")
    created_at: "2017-04-06T13:44:18.281Z", display_name: "Papers We Love",
    followers_count: 1, following_count: 1,
    header: "https://social.lou.lt/system/accounts/headers/000/007/126/original/missing.png?1491486258",
-   id: 7126, locked: false,
+   id: "7126", locked: false,
    note: "Building Bridges Between Academia and Industry\n\n<a href=\"http://paperswelove.org\" rel=\"nofollow noopener\"><span class=\"invisible\">http://</span><span class=\"\">paperswelove.org</span><span class=\"invisible\"></span></a>\n<a href=\"http://pwlconf.org\" rel=\"nofollow noopener noopener\"><span class=\"invisible\">http://</span><span class=\"\">pwlconf.org</span><span class=\"invisible\"></span></a>",
    statuses_count: 8, url: "https://mstdn.io/@paperswelove",
    username: "paperswelove"}, application: nil,
   content: "<p>One Pass Real-Time Generational Mark-Sweep Garbage Collection - Armstrong, Virding</p><p>Link: <a href=\"http://buff.ly/2pdh7iS\" rel=\"nofollow noopener\"><span class=\"invisible\">http://</span><span class=\"\">buff.ly/2pdh7iS</span><span class=\"invisible\"></span></a> </p><p>In this paper we present a simple scheme for reclaiming data for such language classes with a single pass mark-sweep collector. We also show how the simple scheme can be modified so that the collection can be done in an incremental manner (making it suitable for real-time collection).</p><p><a href=\"https://mstdn.io/tags/garbagecollection\" class=\"mention hashtag\">#<span>garbagecollection</span></a> <a href=\"https://mstdn.io/tags/compsci\" class=\"mention hashtag\">#<span>compsci</span></a> <a href=\"https://mstdn.io/tags/paperswelove\" class=\"mention hashtag\">#<span>paperswelove</span></a></p><p> <a href=\"https://mstdn.io/media/u03CNEJZho1pvTR3q6Y\" rel=\"nofollow noopener noopener\"><span class=\"invisible\">https://</span><span class=\"ellipsis\">mstdn.io/media/u03CNEJZho1pvTR</span><span class=\"invisible\">3q6Y</span></a></p>",
   created_at: "2017-04-10T11:40:45.000Z", favourited: nil, favourites_count: 0,
-  id: 186397, in_reply_to_account_id: nil, in_reply_to_id: nil,
-  media_attachments: [%Hunter.Attachment{id: 10284,
+  id: "186397", in_reply_to_account_id: nil, in_reply_to_id: nil,
+  media_attachments: [%Hunter.Attachment{id: "10284",
     preview_url: "https://social.lou.lt/system/media_attachments/files/000/010/284/small/b0432b95264e141c.png?1491824449",
     remote_url: "https://mstdn.io/system/media_attachments/files/000/009/562/original/b0432b95264e141c.png",
     text_url: nil, type: "image",
@@ -442,7 +442,7 @@ iex> Hunter.update_credentials(conn, %{note: "Enum.random(~w(programming cycling
  avatar: "https://social.lou.lt/avatars/original/missing.png",
  created_at: "2017-04-06T17:43:55.325Z", display_name: "Milton Mazzarri",
  followers_count: 4, following_count: 4,
- header: "https://social.lou.lt/headers/original/missing.png", id: 8039,
+ header: "https://social.lou.lt/headers/original/missing.png", id: "8039",
  locked: false,
  note: "Enum.random(~w(programming cycling tennis elixir learning mojitos grill))",
  statuses_count: 3, url: "https://social.lou.lt/@milmazz", username: "milmazz"}

--- a/lib/hunter.ex
+++ b/lib/hunter.ex
@@ -44,7 +44,7 @@ defmodule Hunter do
     * `id` - account identifier
 
   """
-  @spec account(Hunter.Client.t(), non_neg_integer) :: Hunter.Account.t()
+  @spec account(Hunter.Client.t(), String.t() | non_neg_integer) :: Hunter.Account.t()
   defdelegate account(conn, id), to: Hunter.Account
 
   @doc """
@@ -63,7 +63,9 @@ defmodule Hunter do
     * `limit` - maximum number of followers to get, default: 40, maximum: 80
 
   """
-  @spec followers(Hunter.Client.t(), non_neg_integer, Keyword.t()) :: [Hunter.Account.t()]
+  @spec followers(Hunter.Client.t(), String.t() | non_neg_integer, Keyword.t()) :: [
+          Hunter.Account.t()
+        ]
   defdelegate followers(conn, id, options \\ []), to: Hunter.Account
 
   @doc """
@@ -82,7 +84,9 @@ defmodule Hunter do
     * `limit` - maximum number of followings to get, default: 40, maximum: 80
 
   """
-  @spec following(Hunter.Client.t(), non_neg_integer, Keyword.t()) :: [Hunter.Account.t()]
+  @spec following(Hunter.Client.t(), String.t() | non_neg_integer, Keyword.t()) :: [
+          Hunter.Account.t()
+        ]
   defdelegate following(conn, id, options \\ []), to: Hunter.Account
 
   @doc """
@@ -164,7 +168,8 @@ defmodule Hunter do
     * `id` - follow request id
 
   """
-  @spec accept_follow_request(Hunter.Client.t(), non_neg_integer) :: Hunter.Relationship.t()
+  @spec accept_follow_request(Hunter.Client.t(), String.t() | non_neg_integer) ::
+          Hunter.Relationship.t()
   defdelegate accept_follow_request(conn, id), to: Hunter.Account
 
   @doc """
@@ -176,7 +181,8 @@ defmodule Hunter do
     * `id` - follow request id
 
   """
-  @spec reject_follow_request(Hunter.Client.t(), non_neg_integer) :: Hunter.Relationship.t()
+  @spec reject_follow_request(Hunter.Client.t(), String.t() | non_neg_integer) ::
+          Hunter.Relationship.t()
   defdelegate reject_follow_request(conn, id), to: Hunter.Account
 
   ## Application
@@ -282,7 +288,7 @@ defmodule Hunter do
     * `id` - attachment identifier
 
   """
-  @spec media_attachment(Hunter.Client.t(), non_neg_integer) :: Hunter.Attachment.t()
+  @spec media_attachment(Hunter.Client.t(), String.t() | non_neg_integer) :: Hunter.Attachment.t()
   defdelegate media_attachment(conn, id), to: Hunter.Attachment
 
   @doc """
@@ -301,7 +307,8 @@ defmodule Hunter do
     * `thumbnail` - path of a custom thumbnail image
 
   """
-  @spec update_media(Hunter.Client.t(), non_neg_integer, Keyword.t()) :: Hunter.Attachment.t()
+  @spec update_media(Hunter.Client.t(), String.t() | non_neg_integer, Keyword.t()) ::
+          Hunter.Attachment.t()
   defdelegate update_media(conn, id, options \\ []), to: Hunter.Attachment
 
   @doc """
@@ -313,7 +320,7 @@ defmodule Hunter do
     * `id` - attachment identifier
 
   """
-  @spec delete_media(Hunter.Client.t(), non_neg_integer) :: boolean
+  @spec delete_media(Hunter.Client.t(), String.t() | non_neg_integer) :: boolean
   defdelegate delete_media(conn, id), to: Hunter.Attachment
 
   @doc """
@@ -325,7 +332,9 @@ defmodule Hunter do
     * `id` - list of relationship IDs
 
   """
-  @spec relationships(Hunter.Client.t(), [non_neg_integer]) :: [Hunter.Relationship.t()]
+  @spec relationships(Hunter.Client.t(), [String.t() | non_neg_integer]) :: [
+          Hunter.Relationship.t()
+        ]
   defdelegate relationships(conn, ids), to: Hunter.Relationship
 
   @doc """
@@ -337,7 +346,7 @@ defmodule Hunter do
     * `id` - user identifier
 
   """
-  @spec follow(Hunter.Client.t(), non_neg_integer) :: Hunter.Relationship.t()
+  @spec follow(Hunter.Client.t(), String.t() | non_neg_integer) :: Hunter.Relationship.t()
   defdelegate follow(conn, id), to: Hunter.Relationship
 
   @doc """
@@ -349,7 +358,7 @@ defmodule Hunter do
     * `id` - user identifier
 
   """
-  @spec unfollow(Hunter.Client.t(), non_neg_integer) :: Hunter.Relationship.t()
+  @spec unfollow(Hunter.Client.t(), String.t() | non_neg_integer) :: Hunter.Relationship.t()
   defdelegate unfollow(conn, id), to: Hunter.Relationship
 
   @doc """
@@ -361,7 +370,7 @@ defmodule Hunter do
     * `id` - user identifier
 
   """
-  @spec block(Hunter.Client.t(), non_neg_integer) :: Hunter.Relationship.t()
+  @spec block(Hunter.Client.t(), String.t() | non_neg_integer) :: Hunter.Relationship.t()
   defdelegate block(conn, id), to: Hunter.Relationship
 
   @doc """
@@ -371,7 +380,7 @@ defmodule Hunter do
     * `id` - user identifier
 
   """
-  @spec unblock(Hunter.Client.t(), non_neg_integer) :: Hunter.Relationship.t()
+  @spec unblock(Hunter.Client.t(), String.t() | non_neg_integer) :: Hunter.Relationship.t()
   defdelegate unblock(conn, id), to: Hunter.Relationship
 
   @doc """
@@ -383,7 +392,7 @@ defmodule Hunter do
     * `id` - user identifier
 
   """
-  @spec mute(Hunter.Client.t(), non_neg_integer) :: Hunter.Relationship.t()
+  @spec mute(Hunter.Client.t(), String.t() | non_neg_integer) :: Hunter.Relationship.t()
   defdelegate mute(conn, id), to: Hunter.Relationship
 
   @doc """
@@ -395,7 +404,7 @@ defmodule Hunter do
     * `id` - user identifier
 
   """
-  @spec unmute(Hunter.Client.t(), non_neg_integer) :: Hunter.Relationship.t()
+  @spec unmute(Hunter.Client.t(), String.t() | non_neg_integer) :: Hunter.Relationship.t()
   defdelegate unmute(conn, id), to: Hunter.Relationship
 
   @doc """
@@ -455,7 +464,7 @@ defmodule Hunter do
     * `id` - poll identifier
 
   """
-  @spec poll(Hunter.Client.t(), non_neg_integer) :: Hunter.Poll.t()
+  @spec poll(Hunter.Client.t(), String.t() | non_neg_integer) :: Hunter.Poll.t()
   defdelegate poll(conn, id), to: Hunter.Poll
 
   @doc """
@@ -468,7 +477,8 @@ defmodule Hunter do
     * `choices` - list of option indices to vote for (zero-based)
 
   """
-  @spec vote(Hunter.Client.t(), non_neg_integer, [non_neg_integer]) :: Hunter.Poll.t()
+  @spec vote(Hunter.Client.t(), String.t() | non_neg_integer, [non_neg_integer]) ::
+          Hunter.Poll.t()
   defdelegate vote(conn, id, choices), to: Hunter.Poll
 
   @doc """
@@ -480,7 +490,7 @@ defmodule Hunter do
     * `id` - status identifier
 
   """
-  @spec status(Hunter.Client.t(), non_neg_integer) :: Hunter.Status.t()
+  @spec status(Hunter.Client.t(), String.t() | non_neg_integer) :: Hunter.Status.t()
   defdelegate status(conn, id), to: Hunter.Status
 
   @doc """
@@ -492,7 +502,7 @@ defmodule Hunter do
     * `ids` - list of status identifiers
 
   """
-  @spec statuses_by_ids(Hunter.Client.t(), [non_neg_integer]) :: [Hunter.Status.t()]
+  @spec statuses_by_ids(Hunter.Client.t(), [String.t() | non_neg_integer]) :: [Hunter.Status.t()]
   defdelegate statuses_by_ids(conn, ids), to: Hunter.Status
 
   @doc """
@@ -515,7 +525,7 @@ defmodule Hunter do
       (seconds); replaces the current poll
 
   """
-  @spec edit_status(Hunter.Client.t(), non_neg_integer, String.t(), Keyword.t()) ::
+  @spec edit_status(Hunter.Client.t(), String.t() | non_neg_integer, String.t(), Keyword.t()) ::
           Hunter.Status.t() | no_return
   defdelegate edit_status(conn, id, status, options \\ []), to: Hunter.Status
 
@@ -528,7 +538,7 @@ defmodule Hunter do
     * `id` - status identifier
 
   """
-  @spec status_history(Hunter.Client.t(), non_neg_integer) :: [Hunter.StatusEdit.t()]
+  @spec status_history(Hunter.Client.t(), String.t() | non_neg_integer) :: [Hunter.StatusEdit.t()]
   defdelegate status_history(conn, id), to: Hunter.Status
 
   @doc """
@@ -540,7 +550,7 @@ defmodule Hunter do
     * `id` - status identifier
 
   """
-  @spec status_source(Hunter.Client.t(), non_neg_integer) :: Hunter.StatusSource.t()
+  @spec status_source(Hunter.Client.t(), String.t() | non_neg_integer) :: Hunter.StatusSource.t()
   defdelegate status_source(conn, id), to: Hunter.Status
 
   @doc """
@@ -552,7 +562,7 @@ defmodule Hunter do
     * `id` - status identifier
 
   """
-  @spec bookmark(Hunter.Client.t(), non_neg_integer) :: Hunter.Status.t()
+  @spec bookmark(Hunter.Client.t(), String.t() | non_neg_integer) :: Hunter.Status.t()
   defdelegate bookmark(conn, id), to: Hunter.Status
 
   @doc """
@@ -564,7 +574,7 @@ defmodule Hunter do
     * `id` - status identifier
 
   """
-  @spec unbookmark(Hunter.Client.t(), non_neg_integer) :: Hunter.Status.t()
+  @spec unbookmark(Hunter.Client.t(), String.t() | non_neg_integer) :: Hunter.Status.t()
   defdelegate unbookmark(conn, id), to: Hunter.Status
 
   @doc """
@@ -596,7 +606,7 @@ defmodule Hunter do
     * `id` - status identifier
 
   """
-  @spec pin(Hunter.Client.t(), non_neg_integer) :: Hunter.Status.t()
+  @spec pin(Hunter.Client.t(), String.t() | non_neg_integer) :: Hunter.Status.t()
   defdelegate pin(conn, id), to: Hunter.Status
 
   @doc """
@@ -608,7 +618,7 @@ defmodule Hunter do
     * `id` - status identifier
 
   """
-  @spec unpin(Hunter.Client.t(), non_neg_integer) :: Hunter.Status.t()
+  @spec unpin(Hunter.Client.t(), String.t() | non_neg_integer) :: Hunter.Status.t()
   defdelegate unpin(conn, id), to: Hunter.Status
 
   @doc """
@@ -620,7 +630,7 @@ defmodule Hunter do
     * `id` - status identifier
 
   """
-  @spec mute_conversation(Hunter.Client.t(), non_neg_integer) :: Hunter.Status.t()
+  @spec mute_conversation(Hunter.Client.t(), String.t() | non_neg_integer) :: Hunter.Status.t()
   defdelegate mute_conversation(conn, id), to: Hunter.Status
 
   @doc """
@@ -632,7 +642,7 @@ defmodule Hunter do
     * `id` - status identifier
 
   """
-  @spec unmute_conversation(Hunter.Client.t(), non_neg_integer) :: Hunter.Status.t()
+  @spec unmute_conversation(Hunter.Client.t(), String.t() | non_neg_integer) :: Hunter.Status.t()
   defdelegate unmute_conversation(conn, id), to: Hunter.Status
 
   @doc """
@@ -650,7 +660,7 @@ defmodule Hunter do
       defaults to the user's current locale
 
   """
-  @spec translate_status(Hunter.Client.t(), non_neg_integer, Keyword.t()) ::
+  @spec translate_status(Hunter.Client.t(), String.t() | non_neg_integer, Keyword.t()) ::
           Hunter.Translation.t()
   defdelegate translate_status(conn, id, options \\ []), to: Hunter.Status
 
@@ -663,7 +673,7 @@ defmodule Hunter do
     * `id` - status identifier
 
   """
-  @spec destroy_status(Hunter.Client.t(), non_neg_integer) :: boolean
+  @spec destroy_status(Hunter.Client.t(), String.t() | non_neg_integer) :: boolean
   defdelegate destroy_status(conn, id), to: Hunter.Status
 
   @doc """
@@ -675,7 +685,7 @@ defmodule Hunter do
     * `id` - status identifier
 
   """
-  @spec reblog(Hunter.Client.t(), non_neg_integer) :: Hunter.Status.t()
+  @spec reblog(Hunter.Client.t(), String.t() | non_neg_integer) :: Hunter.Status.t()
   defdelegate reblog(conn, id), to: Hunter.Status
 
   @doc """
@@ -687,7 +697,7 @@ defmodule Hunter do
   * `id` - status identifier
 
   """
-  @spec unreblog(Hunter.Client.t(), non_neg_integer) :: Hunter.Status.t()
+  @spec unreblog(Hunter.Client.t(), String.t() | non_neg_integer) :: Hunter.Status.t()
   defdelegate unreblog(conn, id), to: Hunter.Status
 
   @doc """
@@ -706,7 +716,9 @@ defmodule Hunter do
     * `limit` - maximum number of *reblogged by* to get, default: 40, max: 80
 
   """
-  @spec reblogged_by(Hunter.Client.t(), non_neg_integer, Keyword.t()) :: [Hunter.Account.t()]
+  @spec reblogged_by(Hunter.Client.t(), String.t() | non_neg_integer, Keyword.t()) :: [
+          Hunter.Account.t()
+        ]
   defdelegate reblogged_by(conn, id, options \\ []), to: Hunter.Account
 
   @doc """
@@ -718,7 +730,7 @@ defmodule Hunter do
     * `id` - status identifier
 
   """
-  @spec favourite(Hunter.Client.t(), non_neg_integer) :: Hunter.Status.t()
+  @spec favourite(Hunter.Client.t(), String.t() | non_neg_integer) :: Hunter.Status.t()
   defdelegate favourite(conn, id), to: Hunter.Status
 
   @doc """
@@ -730,7 +742,7 @@ defmodule Hunter do
     * `id` - status identifier
 
   """
-  @spec unfavourite(Hunter.Client.t(), non_neg_integer) :: Hunter.Status.t()
+  @spec unfavourite(Hunter.Client.t(), String.t() | non_neg_integer) :: Hunter.Status.t()
   defdelegate unfavourite(conn, id), to: Hunter.Status
 
   @doc """
@@ -768,7 +780,9 @@ defmodule Hunter do
 
   """
 
-  @spec favourited_by(Hunter.Client.t(), non_neg_integer, Keyword.t()) :: [Hunter.Account.t()]
+  @spec favourited_by(Hunter.Client.t(), String.t() | non_neg_integer, Keyword.t()) :: [
+          Hunter.Account.t()
+        ]
   defdelegate favourited_by(conn, id, options \\ []), to: Hunter.Account
 
   @doc """
@@ -789,7 +803,9 @@ defmodule Hunter do
     * `limit` - maximum number of statuses to get, default: 20, max: 40
 
   """
-  @spec statuses(Hunter.Client.t(), non_neg_integer, Keyword.t()) :: [Hunter.Status.t()]
+  @spec statuses(Hunter.Client.t(), String.t() | non_neg_integer, Keyword.t()) :: [
+          Hunter.Status.t()
+        ]
   defdelegate statuses(conn, account_id, options \\ []), to: Hunter.Status
 
   @doc """
@@ -865,7 +881,9 @@ defmodule Hunter do
     * `limit` - maximum number of statuses on the requested timeline to get, default: 20, max: 40
 
   """
-  @spec list_timeline(Hunter.Client.t(), non_neg_integer, Keyword.t()) :: [Hunter.Status.t()]
+  @spec list_timeline(Hunter.Client.t(), String.t() | non_neg_integer, Keyword.t()) :: [
+          Hunter.Status.t()
+        ]
   defdelegate list_timeline(conn, list_id, options \\ []), to: Hunter.Status
 
   @doc """
@@ -888,7 +906,7 @@ defmodule Hunter do
     * `id` - list identifier
 
   """
-  @spec list(Hunter.Client.t(), non_neg_integer) :: Hunter.List.t()
+  @spec list(Hunter.Client.t(), String.t() | non_neg_integer) :: Hunter.List.t()
   defdelegate list(conn, id), to: Hunter.List
 
   @doc """
@@ -929,7 +947,8 @@ defmodule Hunter do
       timeline
 
   """
-  @spec update_list(Hunter.Client.t(), non_neg_integer, Keyword.t()) :: Hunter.List.t()
+  @spec update_list(Hunter.Client.t(), String.t() | non_neg_integer, Keyword.t()) ::
+          Hunter.List.t()
   defdelegate update_list(conn, id, options), to: Hunter.List
 
   @doc """
@@ -941,7 +960,7 @@ defmodule Hunter do
     * `id` - list identifier
 
   """
-  @spec destroy_list(Hunter.Client.t(), non_neg_integer) :: boolean
+  @spec destroy_list(Hunter.Client.t(), String.t() | non_neg_integer) :: boolean
   defdelegate destroy_list(conn, id), to: Hunter.List
 
   @doc """
@@ -961,7 +980,9 @@ defmodule Hunter do
       get all accounts in the list
 
   """
-  @spec list_accounts(Hunter.Client.t(), non_neg_integer, Keyword.t()) :: [Hunter.Account.t()]
+  @spec list_accounts(Hunter.Client.t(), String.t() | non_neg_integer, Keyword.t()) :: [
+          Hunter.Account.t()
+        ]
   defdelegate list_accounts(conn, id, options \\ []), to: Hunter.List
 
   @doc """
@@ -974,7 +995,9 @@ defmodule Hunter do
     * `account_ids` - account identifiers to add
 
   """
-  @spec add_accounts_to_list(Hunter.Client.t(), non_neg_integer, [non_neg_integer]) :: boolean
+  @spec add_accounts_to_list(Hunter.Client.t(), String.t() | non_neg_integer, [
+          String.t() | non_neg_integer
+        ]) :: boolean
   defdelegate add_accounts_to_list(conn, id, account_ids), to: Hunter.List
 
   @doc """
@@ -987,7 +1010,9 @@ defmodule Hunter do
     * `account_ids` - account identifiers to remove
 
   """
-  @spec remove_accounts_from_list(Hunter.Client.t(), non_neg_integer, [non_neg_integer]) ::
+  @spec remove_accounts_from_list(Hunter.Client.t(), String.t() | non_neg_integer, [
+          String.t() | non_neg_integer
+        ]) ::
           boolean
   defdelegate remove_accounts_from_list(conn, id, account_ids), to: Hunter.List
 
@@ -1000,7 +1025,7 @@ defmodule Hunter do
     * `account_id` - account identifier
 
   """
-  @spec account_lists(Hunter.Client.t(), non_neg_integer) :: [Hunter.List.t()]
+  @spec account_lists(Hunter.Client.t(), String.t() | non_neg_integer) :: [Hunter.List.t()]
   defdelegate account_lists(conn, account_id), to: Hunter.List
 
   @doc """
@@ -1041,7 +1066,7 @@ defmodule Hunter do
     * `id` - notification identifier
 
   """
-  @spec notification(Hunter.Client.t(), non_neg_integer) :: Hunter.Notification.t()
+  @spec notification(Hunter.Client.t(), String.t() | non_neg_integer) :: Hunter.Notification.t()
   defdelegate notification(conn, id), to: Hunter.Notification
 
   @doc """
@@ -1064,7 +1089,7 @@ defmodule Hunter do
     * `id` - notification id
 
   """
-  @spec clear_notification(Hunter.Client.t(), non_neg_integer) :: boolean
+  @spec clear_notification(Hunter.Client.t(), String.t() | non_neg_integer) :: boolean
   defdelegate clear_notification(conn, id), to: Hunter.Notification
 
   @doc """
@@ -1078,7 +1103,12 @@ defmodule Hunter do
     * `comment` - a comment to associate with the report
 
   """
-  @spec report(Hunter.Client.t(), non_neg_integer, [non_neg_integer], String.t()) ::
+  @spec report(
+          Hunter.Client.t(),
+          String.t() | non_neg_integer,
+          [String.t() | non_neg_integer],
+          String.t()
+        ) ::
           Hunter.Report.t()
   defdelegate report(conn, account_id, status_ids, comment), to: Hunter.Report
 
@@ -1091,7 +1121,7 @@ defmodule Hunter do
     * `id` - status identifier
 
   """
-  @spec status_context(Hunter.Client.t(), non_neg_integer) :: Hunter.Context.t()
+  @spec status_context(Hunter.Client.t(), String.t() | non_neg_integer) :: Hunter.Context.t()
   defdelegate status_context(conn, id), to: Hunter.Context
 
   @doc """

--- a/lib/hunter/account.ex
+++ b/lib/hunter/account.ex
@@ -45,7 +45,7 @@ defmodule Hunter.Account do
   alias Hunter.Api.HTTPClient
 
   @type t :: %__MODULE__{
-          id: non_neg_integer,
+          id: String.t(),
           username: String.t(),
           acct: String.t(),
           display_name: String.t(),
@@ -131,7 +131,7 @@ defmodule Hunter.Account do
                 following_count: 4,
                 header: "https://social.lou.lt/headers/original/missing.png",
                 header_static: "https://social.lou.lt/headers/original/missing.png",
-                id: 8039, locked: false, note: "", statuses_count: 3,
+                id: "8039", locked: false, note: "", statuses_count: 3,
                 url: "https://social.lou.lt/@milmazz", username: "milmazz"}
 
   """
@@ -170,7 +170,7 @@ defmodule Hunter.Account do
     * `id` - account id
 
   """
-  @spec account(Hunter.Client.t(), non_neg_integer) :: Hunter.Account.t()
+  @spec account(Hunter.Client.t(), String.t() | non_neg_integer) :: Hunter.Account.t()
   def account(conn, id) do
     HTTPClient.account(conn, id)
   end
@@ -196,7 +196,9 @@ defmodule Hunter.Account do
   internal key.
 
   """
-  @spec followers(Hunter.Client.t(), non_neg_integer, Keyword.t()) :: [Hunter.Account.t()]
+  @spec followers(Hunter.Client.t(), String.t() | non_neg_integer, Keyword.t()) :: [
+          Hunter.Account.t()
+        ]
   def followers(conn, id, options \\ []) do
     HTTPClient.followers(conn, id, options)
   end
@@ -222,7 +224,9 @@ defmodule Hunter.Account do
   internal key.
 
   """
-  @spec following(Hunter.Client.t(), non_neg_integer, Keyword.t()) :: [Hunter.Account.t()]
+  @spec following(Hunter.Client.t(), String.t() | non_neg_integer, Keyword.t()) :: [
+          Hunter.Account.t()
+        ]
   def following(conn, id, options \\ []) do
     HTTPClient.following(conn, id, options)
   end
@@ -319,7 +323,8 @@ defmodule Hunter.Account do
     * `id` - follow request id
 
   """
-  @spec accept_follow_request(Hunter.Client.t(), non_neg_integer) :: Hunter.Relationship.t()
+  @spec accept_follow_request(Hunter.Client.t(), String.t() | non_neg_integer) ::
+          Hunter.Relationship.t()
   def accept_follow_request(conn, id) do
     HTTPClient.follow_request_action(conn, id, :authorize)
   end
@@ -333,7 +338,8 @@ defmodule Hunter.Account do
     * `id` - follow request id
 
   """
-  @spec reject_follow_request(Hunter.Client.t(), non_neg_integer) :: Hunter.Relationship.t()
+  @spec reject_follow_request(Hunter.Client.t(), String.t() | non_neg_integer) ::
+          Hunter.Relationship.t()
   def reject_follow_request(conn, id) do
     HTTPClient.follow_request_action(conn, id, :reject)
   end
@@ -354,7 +360,9 @@ defmodule Hunter.Account do
     * `limit` - maximum number of *reblogged by* to get, default: 40, max: 80
 
   """
-  @spec reblogged_by(Hunter.Client.t(), non_neg_integer, Keyword.t()) :: [Hunter.Account.t()]
+  @spec reblogged_by(Hunter.Client.t(), String.t() | non_neg_integer, Keyword.t()) :: [
+          Hunter.Account.t()
+        ]
   def reblogged_by(conn, id, options \\ []) do
     HTTPClient.reblogged_by(conn, id, options)
   end
@@ -376,7 +384,9 @@ defmodule Hunter.Account do
 
   """
 
-  @spec favourited_by(Hunter.Client.t(), non_neg_integer, Keyword.t()) :: [Hunter.Account.t()]
+  @spec favourited_by(Hunter.Client.t(), String.t() | non_neg_integer, Keyword.t()) :: [
+          Hunter.Account.t()
+        ]
   def favourited_by(conn, id, options \\ []) do
     HTTPClient.favourited_by(conn, id, options)
   end

--- a/lib/hunter/api/http_client.ex
+++ b/lib/hunter/api/http_client.ex
@@ -110,7 +110,7 @@ defmodule Hunter.Api.HTTPClient do
   def delete_media(conn, id) do
     "/api/v1/media/#{id}"
     |> process_url(conn)
-    |> request!(nil, :delete, [], conn)
+    |> request!(:empty, :delete, [], conn)
   end
 
   def relationships(conn, ids) do
@@ -202,7 +202,7 @@ defmodule Hunter.Api.HTTPClient do
   def destroy_status(conn, id) do
     "/api/v1/statuses/#{id}"
     |> process_url(conn)
-    |> request!(nil, :delete, [], conn)
+    |> request!(:empty, :delete, [], conn)
   end
 
   def statuses_by_ids(conn, ids) do
@@ -354,7 +354,7 @@ defmodule Hunter.Api.HTTPClient do
   def destroy_list(conn, id) do
     "/api/v1/lists/#{id}"
     |> process_url(conn)
-    |> request!(nil, :delete, [], conn)
+    |> request!(:empty, :delete, [], conn)
   end
 
   def list_accounts(conn, id, options) do
@@ -366,13 +366,13 @@ defmodule Hunter.Api.HTTPClient do
   def add_accounts_to_list(conn, id, account_ids) do
     "/api/v1/lists/#{id}/accounts"
     |> process_url(conn)
-    |> request!(nil, :post, %{account_ids: account_ids}, conn)
+    |> request!(:empty, :post, %{account_ids: account_ids}, conn)
   end
 
   def remove_accounts_from_list(conn, id, account_ids) do
     "/api/v1/lists/#{id}/accounts"
     |> process_url(conn)
-    |> request!(nil, :delete, %{account_ids: account_ids}, conn)
+    |> request!(:empty, :delete, %{account_ids: account_ids}, conn)
   end
 
   def account_lists(conn, account_id) do
@@ -408,13 +408,13 @@ defmodule Hunter.Api.HTTPClient do
   def clear_notifications(conn) do
     "/api/v1/notifications/clear"
     |> process_url(conn)
-    |> request!(nil, :post, [], conn)
+    |> request!(:empty, :post, [], conn)
   end
 
   def clear_notification(conn, id) do
     "/api/v1/notifications/#{id}/dismiss"
     |> process_url(conn)
-    |> request!(nil, :post, [], conn)
+    |> request!(:empty, :post, [], conn)
   end
 
   def report(conn, account_id, status_ids, comment) do
@@ -489,13 +489,13 @@ defmodule Hunter.Api.HTTPClient do
   def block_domain(conn, domain) do
     "/api/v1/domain_blocks"
     |> process_url(conn)
-    |> request!(nil, :post, %{domain: domain}, conn)
+    |> request!(:empty, :post, %{domain: domain}, conn)
   end
 
   def unblock_domain(conn, domain) do
     "/api/v1/domain_blocks"
     |> process_url(conn)
-    |> request!(nil, :delete, %{domain: domain}, conn)
+    |> request!(:empty, :delete, %{domain: domain}, conn)
   end
 
   ## Helpers

--- a/lib/hunter/api/transformer.ex
+++ b/lib/hunter/api/transformer.ex
@@ -158,6 +158,9 @@ defmodule Hunter.Api.Transformer do
     )
   end
 
+  # fire-and-forget endpoints whose response body carries no information
+  def transform(_body, :empty), do: true
+
   def transform(body, _), do: Poison.decode!(body)
 
   defp account_nested_struct do

--- a/lib/hunter/application.ex
+++ b/lib/hunter/application.ex
@@ -28,7 +28,7 @@ defmodule Hunter.Application do
   alias Hunter.Config
 
   @type t :: %__MODULE__{
-          id: non_neg_integer,
+          id: String.t(),
           name: String.t() | nil,
           website: String.t() | nil,
           client_id: String.t(),
@@ -86,7 +86,7 @@ defmodule Hunter.Application do
       iex> Hunter.Application.create_app("hunter", "urn:ietf:wg:oauth:2.0:oob", ["read", "write", "follow"], nil, [save?: true, api_base_url: "https://example.com"])
       %Hunter.Application{client_id: "1234567890",
        client_secret: "1234567890",
-       id: 1234}
+       id: "1234"}
 
   """
   @spec create_app(String.t(), String.t(), [String.t()], nil | String.t(), Keyword.t()) ::

--- a/lib/hunter/attachment.ex
+++ b/lib/hunter/attachment.ex
@@ -29,7 +29,7 @@ defmodule Hunter.Attachment do
   alias Hunter.Api.HTTPClient
 
   @type t :: %__MODULE__{
-          id: non_neg_integer,
+          id: String.t(),
           type: String.t(),
           url: String.t(),
           remote_url: String.t(),
@@ -89,7 +89,7 @@ defmodule Hunter.Attachment do
     * `id` - attachment identifier
 
   """
-  @spec media_attachment(Hunter.Client.t(), non_neg_integer) :: Hunter.Attachment.t()
+  @spec media_attachment(Hunter.Client.t(), String.t() | non_neg_integer) :: Hunter.Attachment.t()
   def media_attachment(conn, id) do
     HTTPClient.media_attachment(conn, id)
   end
@@ -110,7 +110,8 @@ defmodule Hunter.Attachment do
     * `thumbnail` - path of a custom thumbnail image
 
   """
-  @spec update_media(Hunter.Client.t(), non_neg_integer, Keyword.t()) :: Hunter.Attachment.t()
+  @spec update_media(Hunter.Client.t(), String.t() | non_neg_integer, Keyword.t()) ::
+          Hunter.Attachment.t()
   def update_media(conn, id, options \\ []) do
     HTTPClient.update_media(conn, id, options)
   end
@@ -124,7 +125,7 @@ defmodule Hunter.Attachment do
     * `id` - attachment identifier
 
   """
-  @spec delete_media(Hunter.Client.t(), non_neg_integer) :: boolean
+  @spec delete_media(Hunter.Client.t(), String.t() | non_neg_integer) :: boolean
   def delete_media(conn, id) do
     HTTPClient.delete_media(conn, id)
   end

--- a/lib/hunter/context.ex
+++ b/lib/hunter/context.ex
@@ -27,7 +27,7 @@ defmodule Hunter.Context do
     * `id` - status identifier
 
   """
-  @spec status_context(Hunter.Client.t(), non_neg_integer) :: Hunter.Context.t()
+  @spec status_context(Hunter.Client.t(), String.t() | non_neg_integer) :: Hunter.Context.t()
   def status_context(conn, id) do
     HTTPClient.status_context(conn, id)
   end

--- a/lib/hunter/list.ex
+++ b/lib/hunter/list.ex
@@ -48,7 +48,7 @@ defmodule Hunter.List do
     * `id` - list identifier
 
   """
-  @spec list(Hunter.Client.t(), non_neg_integer) :: Hunter.List.t()
+  @spec list(Hunter.Client.t(), String.t() | non_neg_integer) :: Hunter.List.t()
   def list(conn, id) do
     HTTPClient.list(conn, id)
   end
@@ -93,7 +93,8 @@ defmodule Hunter.List do
       timeline
 
   """
-  @spec update_list(Hunter.Client.t(), non_neg_integer, Keyword.t()) :: Hunter.List.t()
+  @spec update_list(Hunter.Client.t(), String.t() | non_neg_integer, Keyword.t()) ::
+          Hunter.List.t()
   def update_list(conn, id, options) do
     HTTPClient.update_list(conn, id, options)
   end
@@ -107,7 +108,7 @@ defmodule Hunter.List do
     * `id` - list identifier
 
   """
-  @spec destroy_list(Hunter.Client.t(), non_neg_integer) :: boolean
+  @spec destroy_list(Hunter.Client.t(), String.t() | non_neg_integer) :: boolean
   def destroy_list(conn, id) do
     HTTPClient.destroy_list(conn, id)
   end
@@ -129,7 +130,9 @@ defmodule Hunter.List do
       get all accounts in the list
 
   """
-  @spec list_accounts(Hunter.Client.t(), non_neg_integer, Keyword.t()) :: [Hunter.Account.t()]
+  @spec list_accounts(Hunter.Client.t(), String.t() | non_neg_integer, Keyword.t()) :: [
+          Hunter.Account.t()
+        ]
   def list_accounts(conn, id, options \\ []) do
     HTTPClient.list_accounts(conn, id, options)
   end
@@ -144,7 +147,9 @@ defmodule Hunter.List do
     * `account_ids` - account identifiers to add
 
   """
-  @spec add_accounts_to_list(Hunter.Client.t(), non_neg_integer, [non_neg_integer]) :: boolean
+  @spec add_accounts_to_list(Hunter.Client.t(), String.t() | non_neg_integer, [
+          String.t() | non_neg_integer
+        ]) :: boolean
   def add_accounts_to_list(conn, id, account_ids) do
     HTTPClient.add_accounts_to_list(conn, id, account_ids)
   end
@@ -159,7 +164,9 @@ defmodule Hunter.List do
     * `account_ids` - account identifiers to remove
 
   """
-  @spec remove_accounts_from_list(Hunter.Client.t(), non_neg_integer, [non_neg_integer]) ::
+  @spec remove_accounts_from_list(Hunter.Client.t(), String.t() | non_neg_integer, [
+          String.t() | non_neg_integer
+        ]) ::
           boolean
   def remove_accounts_from_list(conn, id, account_ids) do
     HTTPClient.remove_accounts_from_list(conn, id, account_ids)
@@ -174,7 +181,7 @@ defmodule Hunter.List do
     * `account_id` - account identifier
 
   """
-  @spec account_lists(Hunter.Client.t(), non_neg_integer) :: [Hunter.List.t()]
+  @spec account_lists(Hunter.Client.t(), String.t() | non_neg_integer) :: [Hunter.List.t()]
   def account_lists(conn, account_id) do
     HTTPClient.account_lists(conn, account_id)
   end

--- a/lib/hunter/mention.ex
+++ b/lib/hunter/mention.ex
@@ -14,7 +14,7 @@ defmodule Hunter.Mention do
           url: String.t(),
           username: String.t(),
           acct: String.t(),
-          id: non_neg_integer
+          id: String.t()
         }
 
   @derive [Poison.Encoder]

--- a/lib/hunter/notification.ex
+++ b/lib/hunter/notification.ex
@@ -89,7 +89,7 @@ defmodule Hunter.Notification do
       #=> %Hunter.Notification{account: %{"acct" => "paperswelove@mstdn.io", ...}
 
   """
-  @spec notification(Hunter.Client.t(), non_neg_integer) :: Hunter.Notification.t()
+  @spec notification(Hunter.Client.t(), String.t() | non_neg_integer) :: Hunter.Notification.t()
   def notification(conn, id) do
     HTTPClient.notification(conn, id)
   end
@@ -116,7 +116,7 @@ defmodule Hunter.Notification do
     * `id` - notification id
 
   """
-  @spec clear_notification(Hunter.Client.t(), non_neg_integer) :: boolean
+  @spec clear_notification(Hunter.Client.t(), String.t() | non_neg_integer) :: boolean
   def clear_notification(conn, id) do
     HTTPClient.clear_notification(conn, id)
   end

--- a/lib/hunter/poll.ex
+++ b/lib/hunter/poll.ex
@@ -58,7 +58,7 @@ defmodule Hunter.Poll do
     * `id` - poll identifier
 
   """
-  @spec poll(Hunter.Client.t(), non_neg_integer) :: Hunter.Poll.t()
+  @spec poll(Hunter.Client.t(), String.t() | non_neg_integer) :: Hunter.Poll.t()
   def poll(conn, id) do
     HTTPClient.poll(conn, id)
   end
@@ -74,7 +74,8 @@ defmodule Hunter.Poll do
       choices are only allowed on multiple-choice polls
 
   """
-  @spec vote(Hunter.Client.t(), non_neg_integer, [non_neg_integer]) :: Hunter.Poll.t()
+  @spec vote(Hunter.Client.t(), String.t() | non_neg_integer, [non_neg_integer]) ::
+          Hunter.Poll.t()
   def vote(conn, id, choices) do
     HTTPClient.vote(conn, id, choices)
   end

--- a/lib/hunter/relationship.ex
+++ b/lib/hunter/relationship.ex
@@ -28,7 +28,7 @@ defmodule Hunter.Relationship do
   alias Hunter.Api.HTTPClient
 
   @type t :: %__MODULE__{
-          id: non_neg_integer,
+          id: String.t(),
           following: boolean,
           showing_reblogs: boolean,
           notifying: boolean,
@@ -75,7 +75,9 @@ defmodule Hunter.Relationship do
     * `id` - list of relationship IDs
 
   """
-  @spec relationships(Hunter.Client.t(), [non_neg_integer]) :: [Hunter.Relationship.t()]
+  @spec relationships(Hunter.Client.t(), [String.t() | non_neg_integer]) :: [
+          Hunter.Relationship.t()
+        ]
   def relationships(conn, ids) do
     HTTPClient.relationships(conn, ids)
   end
@@ -89,7 +91,7 @@ defmodule Hunter.Relationship do
     * `id` - user id
 
   """
-  @spec follow(Hunter.Client.t(), non_neg_integer) :: Hunter.Relationship.t()
+  @spec follow(Hunter.Client.t(), String.t() | non_neg_integer) :: Hunter.Relationship.t()
   def follow(conn, id) do
     HTTPClient.follow(conn, id)
   end
@@ -103,7 +105,7 @@ defmodule Hunter.Relationship do
     * `id` - user id
 
   """
-  @spec unfollow(Hunter.Client.t(), non_neg_integer) :: Hunter.Relationship.t()
+  @spec unfollow(Hunter.Client.t(), String.t() | non_neg_integer) :: Hunter.Relationship.t()
   def unfollow(conn, id) do
     HTTPClient.unfollow(conn, id)
   end
@@ -117,7 +119,7 @@ defmodule Hunter.Relationship do
     * `id` - user id
 
   """
-  @spec block(Hunter.Client.t(), non_neg_integer) :: Hunter.Relationship.t()
+  @spec block(Hunter.Client.t(), String.t() | non_neg_integer) :: Hunter.Relationship.t()
   def block(conn, id) do
     HTTPClient.block(conn, id)
   end
@@ -129,7 +131,7 @@ defmodule Hunter.Relationship do
     * `id` - user id
 
   """
-  @spec unblock(Hunter.Client.t(), non_neg_integer) :: Hunter.Relationship.t()
+  @spec unblock(Hunter.Client.t(), String.t() | non_neg_integer) :: Hunter.Relationship.t()
   def unblock(conn, id) do
     HTTPClient.unblock(conn, id)
   end
@@ -143,7 +145,7 @@ defmodule Hunter.Relationship do
     * `id` - user id
 
   """
-  @spec mute(Hunter.Client.t(), non_neg_integer) :: Hunter.Relationship.t()
+  @spec mute(Hunter.Client.t(), String.t() | non_neg_integer) :: Hunter.Relationship.t()
   def mute(conn, id) do
     HTTPClient.mute(conn, id)
   end
@@ -157,7 +159,7 @@ defmodule Hunter.Relationship do
     * `id` - user id
 
   """
-  @spec unmute(Hunter.Client.t(), non_neg_integer) :: Hunter.Relationship.t()
+  @spec unmute(Hunter.Client.t(), String.t() | non_neg_integer) :: Hunter.Relationship.t()
   def unmute(conn, id) do
     HTTPClient.unmute(conn, id)
   end

--- a/lib/hunter/report.ex
+++ b/lib/hunter/report.ex
@@ -14,7 +14,7 @@ defmodule Hunter.Report do
   alias Hunter.Api.HTTPClient
 
   @type t :: %__MODULE__{
-          id: non_neg_integer,
+          id: String.t(),
           action_taken: String.t()
         }
 
@@ -32,7 +32,12 @@ defmodule Hunter.Report do
     * `comment` - a comment to associate with the report
 
   """
-  @spec report(Hunter.Client.t(), non_neg_integer, [non_neg_integer], String.t()) ::
+  @spec report(
+          Hunter.Client.t(),
+          String.t() | non_neg_integer,
+          [String.t() | non_neg_integer],
+          String.t()
+        ) ::
           Hunter.Report.t()
   def report(conn, account_id, status_ids, comment) do
     HTTPClient.report(conn, account_id, status_ids, comment)

--- a/lib/hunter/status.ex
+++ b/lib/hunter/status.ex
@@ -50,12 +50,12 @@ defmodule Hunter.Status do
   alias Hunter.Api.HTTPClient
 
   @type t :: %__MODULE__{
-          id: non_neg_integer,
+          id: String.t(),
           uri: String.t(),
           url: String.t(),
           account: Hunter.Account.t(),
-          in_reply_to_id: non_neg_integer,
-          in_reply_to_account_id: non_neg_integer,
+          in_reply_to_id: String.t() | nil,
+          in_reply_to_account_id: String.t() | nil,
           reblog: Hunter.Status.t() | nil,
           content: String.t(),
           text: String.t() | nil,
@@ -85,7 +85,7 @@ defmodule Hunter.Status do
           quote_approval: map | nil
         }
 
-  @type status_id :: non_neg_integer
+  @type status_id :: String.t() | non_neg_integer
 
   @derive [Poison.Encoder]
   defstruct [
@@ -557,7 +557,9 @@ defmodule Hunter.Status do
     * `limit` - maximum number of statuses on the requested timeline to get, default: 20, max: 40
 
   """
-  @spec list_timeline(Hunter.Client.t(), non_neg_integer, Keyword.t()) :: [Hunter.Status.t()]
+  @spec list_timeline(Hunter.Client.t(), String.t() | non_neg_integer, Keyword.t()) :: [
+          Hunter.Status.t()
+        ]
   def list_timeline(conn, list_id, options \\ []) do
     HTTPClient.list_timeline(conn, list_id, Map.new(options))
   end

--- a/test/hunter/attachment_test.exs
+++ b/test/hunter/attachment_test.exs
@@ -71,7 +71,7 @@ defmodule Hunter.AttachmentTest do
       respond_with(conn, %{})
     end)
 
-    assert Attachment.delete_media(@conn, 22_345_792)
+    assert Attachment.delete_media(@conn, 22_345_792) == true
   end
 
   test "API errors raise Hunter.Error" do

--- a/test/hunter/domain_test.exs
+++ b/test/hunter/domain_test.exs
@@ -23,7 +23,7 @@ defmodule Hunter.DomainTest do
       respond_with(conn, %{})
     end)
 
-    assert Domain.block_domain(@conn, "blocked.example")
+    assert Domain.block_domain(@conn, "blocked.example") == true
   end
 
   test "unblocks a domain with a query param" do
@@ -34,7 +34,7 @@ defmodule Hunter.DomainTest do
       respond_with(conn, %{})
     end)
 
-    assert Domain.unblock_domain(@conn, "blocked.example")
+    assert Domain.unblock_domain(@conn, "blocked.example") == true
   end
 
   test "API errors raise Hunter.Error" do

--- a/test/hunter/list_test.exs
+++ b/test/hunter/list_test.exs
@@ -56,7 +56,7 @@ defmodule Hunter.ListTest do
       respond_with(conn, %{})
     end)
 
-    assert List.destroy_list(@conn, 12_249)
+    assert List.destroy_list(@conn, 12_249) == true
   end
 
   test "returns accounts in a list" do
@@ -79,7 +79,7 @@ defmodule Hunter.ListTest do
       respond_with(conn, %{})
     end)
 
-    assert List.add_accounts_to_list(@conn, 12_249, [8039])
+    assert List.add_accounts_to_list(@conn, 12_249, [8039]) == true
   end
 
   test "removes accounts from a list via query params" do
@@ -90,7 +90,7 @@ defmodule Hunter.ListTest do
       respond_with(conn, %{})
     end)
 
-    assert List.remove_accounts_from_list(@conn, 12_249, [8039])
+    assert List.remove_accounts_from_list(@conn, 12_249, [8039]) == true
   end
 
   test "returns lists containing a given account" do

--- a/test/hunter/notification_test.exs
+++ b/test/hunter/notification_test.exs
@@ -40,7 +40,7 @@ defmodule Hunter.NotificationTest do
       respond_with(conn, %{})
     end)
 
-    assert Notification.clear_notifications(@conn)
+    assert Notification.clear_notifications(@conn) == true
   end
 
   test "dismiss a single notification" do
@@ -50,7 +50,7 @@ defmodule Hunter.NotificationTest do
       respond_with(conn, %{})
     end)
 
-    assert Notification.clear_notification(@conn, 17_476)
+    assert Notification.clear_notification(@conn, 17_476) == true
   end
 
   test "API errors raise Hunter.Error" do

--- a/test/hunter/status_test.exs
+++ b/test/hunter/status_test.exs
@@ -108,7 +108,7 @@ defmodule Hunter.StatusTest do
       respond_with(conn, %{})
     end)
 
-    assert Status.destroy_status(@conn, 153_452)
+    assert Status.destroy_status(@conn, 153_452) == true
   end
 
   test "edits a status" do


### PR DESCRIPTION
Closes #116

Spec-truth pass, done now because #134 deleted the `Hunter.Api` behaviour and with it half the duplicated spec sites.

- **Entity `id` fields** are typed `String.t()` — what Mastodon has returned since 2.0 and what the structs actually held at runtime (`Account`, `Status` incl. `in_reply_to_*`, `Attachment`, `Relationship`, `Application`, `Mention`, `Report`). New-in-#131 entities already used strings.
- **Id parameters** across ~80 `@spec` sites accept `String.t() | non_neg_integer` (both always worked — they're interpolated into paths). `Poll.vote/3` choices stay `[non_neg_integer]` — they're option indexes, not ids.
- **Fire-and-forget endpoints** (`destroy_status`, `destroy_list`, `delete_media`, `clear_notification(s)`, `block_domain`, `unblock_domain`, `add/remove_accounts_to/from_list`) now actually return `true` as their `boolean` specs promised, via a new `:empty` transformer target — previously they leaked the decoded response body (`%{}`). Unit assertions strengthened from truthiness to `== true` (red-first). This is the one behavioral change; noted under breaking changes.
- README/moduledoc example outputs show string ids.

Checks: 168 tests + 2 doctests 0 failures, dialyzer, credo --strict, formatter all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)