### PR TITLE
Notifications v2: requests, filtering policy, grouped notifications, Web Push

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,19 @@
       `config :hunter, req_options: [plug: {Req.Test, MyStub}]`
 
   * Features
+    - Notifications v2 ([#122]): `unread_count/1`, the notification
+      filtering policy (`notification_policy/1`,
+      `update_notification_policy/2`), notification requests
+      (`notification_requests/2`, `notification_request/2`,
+      `accept_notification_request/2`, `dismiss_notification_request/2`,
+      bulk accept/dismiss, `notification_requests_merged?/1`) and grouped
+      notifications (`grouped_notifications/2`, `notification_group/2`,
+      `dismiss_notification_group/2`, `notification_group_accounts/2`,
+      `grouped_unread_count/1`, new `Hunter.GroupedNotificationsResults`
+      entity), all on `Hunter.Notification` and the `Hunter` facade
+    - Web Push subscriptions ([#122]): `create_push_subscription/3`,
+      `push_subscription/1`, `update_push_subscription/2` and
+      `delete_push_subscription/1` on `Hunter.WebPushSubscription`
     - Lists support ([#121]): `lists/1`, `list/2`, `create_list/3`,
       `update_list/3`, `destroy_list/2`, `list_accounts/3`,
       `add_accounts_to_list/3`, `remove_accounts_from_list/3`,
@@ -88,6 +101,7 @@
 [#121]: https://github.com/milmazz/hunter/issues/121
 [#103]: https://github.com/milmazz/hunter/issues/103
 [#116]: https://github.com/milmazz/hunter/issues/116
+[#122]: https://github.com/milmazz/hunter/issues/122
 
 ## v0.6.0
 

--- a/README.md
+++ b/README.md
@@ -363,12 +363,38 @@ Returns a single `Hunter.Notification`
 
 ```elixir
 iex> Hunter.clear_notifications(conn)
-"{}"
+true
 iex> Hunter.notifications(conn)
 []
 ```
 
 Deletes all notifications from the Mastodon server for the authenticated user.
+
+### Grouped notifications and filtering
+
+```elixir
+iex> Hunter.grouped_notifications(conn, types: ["mention"])
+%Hunter.GroupedNotificationsResults{
+  notification_groups: [%Hunter.NotificationGroup{type: "mention", ...}],
+  accounts: [%Hunter.Account{...}],
+  statuses: [%Hunter.Status{...}]
+}
+
+iex> Hunter.unread_count(conn)
+3
+
+iex> Hunter.update_notification_policy(conn, for_not_following: "filter")
+%Hunter.NotificationPolicy{for_not_following: "filter", ...}
+
+iex> Hunter.notification_requests(conn)
+[%Hunter.NotificationRequest{account: %Hunter.Account{...}, ...}]
+```
+
+Filtered notifications become requests that can be accepted
+(`Hunter.accept_notification_request/2`) or dismissed. Web Push delivery is
+managed with `Hunter.create_push_subscription/3`,
+`Hunter.push_subscription/1`, `Hunter.update_push_subscription/2`, and
+`Hunter.delete_push_subscription/1`.
 
 ### Fetch a list of follow requests
 

--- a/lib/hunter.ex
+++ b/lib/hunter.ex
@@ -1093,6 +1093,252 @@ defmodule Hunter do
   defdelegate clear_notification(conn, id), to: Hunter.Notification
 
   @doc """
+  Retrieve the number of unread notifications, capped by the server
+
+  ## Parameters
+
+    * `conn` - connection credentials
+
+  """
+  @spec unread_count(Hunter.Client.t()) :: non_neg_integer
+  defdelegate unread_count(conn), to: Hunter.Notification
+
+  @doc """
+  Retrieve the notification filtering policy for the user
+
+  ## Parameters
+
+    * `conn` - connection credentials
+
+  """
+  @spec notification_policy(Hunter.Client.t()) :: Hunter.NotificationPolicy.t()
+  defdelegate notification_policy(conn), to: Hunter.Notification
+
+  @doc """
+  Update the notification filtering policy for the user
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `options` - option list
+
+  ## Options
+
+  Each takes one of `accept`, `filter` or `drop`:
+
+    * `for_not_following`
+    * `for_not_followers`
+    * `for_new_accounts`
+    * `for_private_mentions`
+    * `for_limited_accounts`
+
+  """
+  @spec update_notification_policy(Hunter.Client.t(), Keyword.t()) ::
+          Hunter.NotificationPolicy.t()
+  defdelegate update_notification_policy(conn, options), to: Hunter.Notification
+
+  @doc """
+  Retrieve notification requests (groups of filtered notifications)
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `options` - option list
+
+  """
+  @spec notification_requests(Hunter.Client.t(), Keyword.t()) :: [
+          Hunter.NotificationRequest.t()
+        ]
+  defdelegate notification_requests(conn, options \\ []), to: Hunter.Notification
+
+  @doc """
+  Retrieve a single notification request
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `id` - notification request identifier
+
+  """
+  @spec notification_request(Hunter.Client.t(), String.t() | non_neg_integer) ::
+          Hunter.NotificationRequest.t()
+  defdelegate notification_request(conn, id), to: Hunter.Notification
+
+  @doc """
+  Accept a notification request
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `id` - notification request identifier
+
+  """
+  @spec accept_notification_request(Hunter.Client.t(), String.t() | non_neg_integer) :: boolean
+  defdelegate accept_notification_request(conn, id), to: Hunter.Notification
+
+  @doc """
+  Dismiss a notification request
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `id` - notification request identifier
+
+  """
+  @spec dismiss_notification_request(Hunter.Client.t(), String.t() | non_neg_integer) :: boolean
+  defdelegate dismiss_notification_request(conn, id), to: Hunter.Notification
+
+  @doc """
+  Accept multiple notification requests
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `ids` - notification request identifiers
+
+  """
+  @spec accept_notification_requests(Hunter.Client.t(), [String.t() | non_neg_integer]) ::
+          boolean
+  defdelegate accept_notification_requests(conn, ids), to: Hunter.Notification
+
+  @doc """
+  Dismiss multiple notification requests
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `ids` - notification request identifiers
+
+  """
+  @spec dismiss_notification_requests(Hunter.Client.t(), [String.t() | non_neg_integer]) ::
+          boolean
+  defdelegate dismiss_notification_requests(conn, ids), to: Hunter.Notification
+
+  @doc """
+  Check whether accepted notification requests have been merged
+
+  ## Parameters
+
+    * `conn` - connection credentials
+
+  """
+  @spec notification_requests_merged?(Hunter.Client.t()) :: boolean
+  defdelegate notification_requests_merged?(conn), to: Hunter.Notification
+
+  @doc """
+  Retrieve grouped notifications, together with the accounts and statuses
+  they reference
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `options` - option list
+
+  """
+  @spec grouped_notifications(Hunter.Client.t(), Keyword.t()) ::
+          Hunter.GroupedNotificationsResults.t()
+  defdelegate grouped_notifications(conn, options \\ []), to: Hunter.Notification
+
+  @doc """
+  Retrieve a single notification group by its group key
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `group_key` - notification group key
+
+  """
+  @spec notification_group(Hunter.Client.t(), String.t()) ::
+          Hunter.GroupedNotificationsResults.t()
+  defdelegate notification_group(conn, group_key), to: Hunter.Notification
+
+  @doc """
+  Dismiss a notification group
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `group_key` - notification group key
+
+  """
+  @spec dismiss_notification_group(Hunter.Client.t(), String.t()) :: boolean
+  defdelegate dismiss_notification_group(conn, group_key), to: Hunter.Notification
+
+  @doc """
+  Retrieve the accounts of all notifications in a notification group
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `group_key` - notification group key
+
+  """
+  @spec notification_group_accounts(Hunter.Client.t(), String.t()) :: [Hunter.Account.t()]
+  defdelegate notification_group_accounts(conn, group_key), to: Hunter.Notification
+
+  @doc """
+  Retrieve the number of unread notification groups, capped by the server
+
+  ## Parameters
+
+    * `conn` - connection credentials
+
+  """
+  @spec grouped_unread_count(Hunter.Client.t()) :: non_neg_integer
+  defdelegate grouped_unread_count(conn), to: Hunter.Notification
+
+  @doc """
+  Subscribe to Web Push notifications; each access token can have exactly
+  one subscription, and creating a new one replaces it
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `subscription` - map with `endpoint`, `keys` (`p256dh` and `auth`)
+      and optionally `standard`
+    * `data` - optional map with `alerts` and `policy`
+
+  """
+  @spec create_push_subscription(Hunter.Client.t(), map, map) ::
+          Hunter.WebPushSubscription.t()
+  defdelegate create_push_subscription(conn, subscription, data \\ %{}),
+    to: Hunter.WebPushSubscription
+
+  @doc """
+  Retrieve the Web Push subscription tied to the access token
+
+  ## Parameters
+
+    * `conn` - connection credentials
+
+  """
+  @spec push_subscription(Hunter.Client.t()) :: Hunter.WebPushSubscription.t()
+  defdelegate push_subscription(conn), to: Hunter.WebPushSubscription
+
+  @doc """
+  Update the `data` portion of the Web Push subscription
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `data` - map with `alerts` and/or `policy`
+
+  """
+  @spec update_push_subscription(Hunter.Client.t(), map) :: Hunter.WebPushSubscription.t()
+  defdelegate update_push_subscription(conn, data), to: Hunter.WebPushSubscription
+
+  @doc """
+  Remove the Web Push subscription tied to the access token
+
+  ## Parameters
+
+    * `conn` - connection credentials
+
+  """
+  @spec delete_push_subscription(Hunter.Client.t()) :: boolean
+  defdelegate delete_push_subscription(conn), to: Hunter.WebPushSubscription
+
+  @doc """
   Report a user
 
   ## Parameters

--- a/lib/hunter/api/http_client.ex
+++ b/lib/hunter/api/http_client.ex
@@ -417,6 +417,123 @@ defmodule Hunter.Api.HTTPClient do
     |> request!(:empty, :post, [], conn)
   end
 
+  def unread_count(conn) do
+    "/api/v1/notifications/unread_count"
+    |> process_url(conn)
+    |> request!(nil, :get, [], conn)
+    |> Map.fetch!("count")
+  end
+
+  def notification_policy(conn) do
+    "/api/v2/notifications/policy"
+    |> process_url(conn)
+    |> request!(:notification_policy, :get, [], conn)
+  end
+
+  def update_notification_policy(conn, options) do
+    "/api/v2/notifications/policy"
+    |> process_url(conn)
+    |> request!(:notification_policy, :patch, Map.new(options), conn)
+  end
+
+  def notification_requests(conn, options) do
+    "/api/v1/notifications/requests"
+    |> process_url(conn)
+    |> request!(:notification_requests, :get, options, conn)
+  end
+
+  def notification_request(conn, id) do
+    "/api/v1/notifications/requests/#{id}"
+    |> process_url(conn)
+    |> request!(:notification_request, :get, [], conn)
+  end
+
+  def accept_notification_request(conn, id) do
+    "/api/v1/notifications/requests/#{id}/accept"
+    |> process_url(conn)
+    |> request!(:empty, :post, [], conn)
+  end
+
+  def dismiss_notification_request(conn, id) do
+    "/api/v1/notifications/requests/#{id}/dismiss"
+    |> process_url(conn)
+    |> request!(:empty, :post, [], conn)
+  end
+
+  def accept_notification_requests(conn, ids) do
+    "/api/v1/notifications/requests/accept"
+    |> process_url(conn)
+    |> request!(:empty, :post, %{id: ids}, conn)
+  end
+
+  def dismiss_notification_requests(conn, ids) do
+    "/api/v1/notifications/requests/dismiss"
+    |> process_url(conn)
+    |> request!(:empty, :post, %{id: ids}, conn)
+  end
+
+  def notification_requests_merged?(conn) do
+    "/api/v1/notifications/requests/merged"
+    |> process_url(conn)
+    |> request!(nil, :get, [], conn)
+    |> Map.fetch!("merged")
+  end
+
+  def grouped_notifications(conn, options) do
+    "/api/v2/notifications"
+    |> process_url(conn)
+    |> request!(:grouped_notifications, :get, options, conn)
+  end
+
+  def notification_group(conn, group_key) do
+    "/api/v2/notifications/#{group_key}"
+    |> process_url(conn)
+    |> request!(:grouped_notifications, :get, [], conn)
+  end
+
+  def dismiss_notification_group(conn, group_key) do
+    "/api/v2/notifications/#{group_key}/dismiss"
+    |> process_url(conn)
+    |> request!(:empty, :post, [], conn)
+  end
+
+  def notification_group_accounts(conn, group_key) do
+    "/api/v2/notifications/#{group_key}/accounts"
+    |> process_url(conn)
+    |> request!(:accounts, :get, [], conn)
+  end
+
+  def grouped_unread_count(conn) do
+    "/api/v2/notifications/unread_count"
+    |> process_url(conn)
+    |> request!(nil, :get, [], conn)
+    |> Map.fetch!("count")
+  end
+
+  def create_push_subscription(conn, subscription, data) do
+    "/api/v1/push/subscription"
+    |> process_url(conn)
+    |> request!(:web_push_subscription, :post, %{subscription: subscription, data: data}, conn)
+  end
+
+  def push_subscription(conn) do
+    "/api/v1/push/subscription"
+    |> process_url(conn)
+    |> request!(:web_push_subscription, :get, [], conn)
+  end
+
+  def update_push_subscription(conn, data) do
+    "/api/v1/push/subscription"
+    |> process_url(conn)
+    |> request!(:web_push_subscription, :put, %{data: data}, conn)
+  end
+
+  def delete_push_subscription(conn) do
+    "/api/v1/push/subscription"
+    |> process_url(conn)
+    |> request!(:empty, :delete, [], conn)
+  end
+
   def report(conn, account_id, status_ids, comment) do
     payload = %{
       account_id: account_id,

--- a/lib/hunter/api/transformer.ex
+++ b/lib/hunter/api/transformer.ex
@@ -56,6 +56,17 @@ defmodule Hunter.Api.Transformer do
   def transform(body, :notification_requests),
     do: Poison.decode!(body, as: [notification_request_nested_struct()])
 
+  def transform(body, :grouped_notifications) do
+    Poison.decode!(
+      body,
+      as: %Hunter.GroupedNotificationsResults{
+        accounts: [account_nested_struct()],
+        statuses: [status_nested_struct()],
+        notification_groups: [notification_group_nested_struct()]
+      }
+    )
+  end
+
   def transform(body, :notification_group),
     do: Poison.decode!(body, as: notification_group_nested_struct())
 

--- a/lib/hunter/grouped_notifications_results.ex
+++ b/lib/hunter/grouped_notifications_results.ex
@@ -1,0 +1,27 @@
+defmodule Hunter.GroupedNotificationsResults do
+  @moduledoc """
+  GroupedNotificationsResults entity
+
+  The response of the grouped notifications API: the notification groups
+  plus the accounts and statuses they reference, deduplicated
+
+  ## Fields
+
+    * `accounts` - list of `Hunter.Account` referenced by the groups
+    * `partial_accounts` - partial account representations, only returned
+      when requesting `expand_accounts=partial_avatars`
+    * `statuses` - list of `Hunter.Status` referenced by the groups
+    * `notification_groups` - list of `Hunter.NotificationGroup`
+
+  """
+
+  @type t :: %__MODULE__{
+          accounts: [Hunter.Account.t()],
+          partial_accounts: [map] | nil,
+          statuses: [Hunter.Status.t()],
+          notification_groups: [Hunter.NotificationGroup.t()]
+        }
+
+  @derive [Poison.Encoder]
+  defstruct [:accounts, :partial_accounts, :statuses, :notification_groups]
+end

--- a/lib/hunter/notification.ex
+++ b/lib/hunter/notification.ex
@@ -120,4 +120,246 @@ defmodule Hunter.Notification do
   def clear_notification(conn, id) do
     HTTPClient.clear_notification(conn, id)
   end
+
+  @doc """
+  Retrieve the number of unread notifications, capped by the server
+
+  ## Parameters
+
+    * `conn` - connection credentials
+
+  """
+  @spec unread_count(Hunter.Client.t()) :: non_neg_integer
+  def unread_count(conn) do
+    HTTPClient.unread_count(conn)
+  end
+
+  @doc """
+  Retrieve the notification filtering policy for the user
+
+  ## Parameters
+
+    * `conn` - connection credentials
+
+  """
+  @spec notification_policy(Hunter.Client.t()) :: Hunter.NotificationPolicy.t()
+  def notification_policy(conn) do
+    HTTPClient.notification_policy(conn)
+  end
+
+  @doc """
+  Update the notification filtering policy for the user
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `options` - option list
+
+  ## Options
+
+  Each takes one of `accept`, `filter` or `drop`:
+
+    * `for_not_following`
+    * `for_not_followers`
+    * `for_new_accounts`
+    * `for_private_mentions`
+    * `for_limited_accounts`
+
+  """
+  @spec update_notification_policy(Hunter.Client.t(), Keyword.t()) ::
+          Hunter.NotificationPolicy.t()
+  def update_notification_policy(conn, options) do
+    HTTPClient.update_notification_policy(conn, options)
+  end
+
+  @doc """
+  Retrieve notification requests (groups of filtered notifications)
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `options` - option list
+
+  ## Options
+
+    * `max_id` - get requests with id less than or equal this value
+    * `since_id` - get requests with id greater than this value
+    * `limit` - maximum number of requests to get, default: 40, max: 80
+
+  """
+  @spec notification_requests(Hunter.Client.t(), Keyword.t()) :: [
+          Hunter.NotificationRequest.t()
+        ]
+  def notification_requests(conn, options \\ []) do
+    HTTPClient.notification_requests(conn, options)
+  end
+
+  @doc """
+  Retrieve a single notification request
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `id` - notification request identifier
+
+  """
+  @spec notification_request(Hunter.Client.t(), String.t() | non_neg_integer) ::
+          Hunter.NotificationRequest.t()
+  def notification_request(conn, id) do
+    HTTPClient.notification_request(conn, id)
+  end
+
+  @doc """
+  Accept a notification request, so future notifications from the account
+  are delivered normally
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `id` - notification request identifier
+
+  """
+  @spec accept_notification_request(Hunter.Client.t(), String.t() | non_neg_integer) :: boolean
+  def accept_notification_request(conn, id) do
+    HTTPClient.accept_notification_request(conn, id)
+  end
+
+  @doc """
+  Dismiss a notification request, removing it and its filtered notifications
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `id` - notification request identifier
+
+  """
+  @spec dismiss_notification_request(Hunter.Client.t(), String.t() | non_neg_integer) :: boolean
+  def dismiss_notification_request(conn, id) do
+    HTTPClient.dismiss_notification_request(conn, id)
+  end
+
+  @doc """
+  Accept multiple notification requests
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `ids` - notification request identifiers
+
+  """
+  @spec accept_notification_requests(Hunter.Client.t(), [String.t() | non_neg_integer]) ::
+          boolean
+  def accept_notification_requests(conn, ids) do
+    HTTPClient.accept_notification_requests(conn, ids)
+  end
+
+  @doc """
+  Dismiss multiple notification requests
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `ids` - notification request identifiers
+
+  """
+  @spec dismiss_notification_requests(Hunter.Client.t(), [String.t() | non_neg_integer]) ::
+          boolean
+  def dismiss_notification_requests(conn, ids) do
+    HTTPClient.dismiss_notification_requests(conn, ids)
+  end
+
+  @doc """
+  Check whether accepted notification requests have been merged into the
+  main notification list
+
+  ## Parameters
+
+    * `conn` - connection credentials
+
+  """
+  @spec notification_requests_merged?(Hunter.Client.t()) :: boolean
+  def notification_requests_merged?(conn) do
+    HTTPClient.notification_requests_merged?(conn)
+  end
+
+  @doc """
+  Retrieve grouped notifications, together with the accounts and statuses
+  they reference
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `options` - option list
+
+  ## Options
+
+    * `max_id` - get groups with id less than or equal this value
+    * `since_id` - get groups with id greater than this value
+    * `limit` - maximum number of groups to get, default: 40, max: 80
+    * `types` - notification types to include
+    * `exclude_types` - notification types to exclude
+    * `grouped_types` - which types can be grouped together
+
+  """
+  @spec grouped_notifications(Hunter.Client.t(), Keyword.t()) ::
+          Hunter.GroupedNotificationsResults.t()
+  def grouped_notifications(conn, options \\ []) do
+    HTTPClient.grouped_notifications(conn, options)
+  end
+
+  @doc """
+  Retrieve a single notification group by its group key
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `group_key` - notification group key
+
+  """
+  @spec notification_group(Hunter.Client.t(), String.t()) ::
+          Hunter.GroupedNotificationsResults.t()
+  def notification_group(conn, group_key) do
+    HTTPClient.notification_group(conn, group_key)
+  end
+
+  @doc """
+  Dismiss a notification group
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `group_key` - notification group key
+
+  """
+  @spec dismiss_notification_group(Hunter.Client.t(), String.t()) :: boolean
+  def dismiss_notification_group(conn, group_key) do
+    HTTPClient.dismiss_notification_group(conn, group_key)
+  end
+
+  @doc """
+  Retrieve the accounts of all notifications in a notification group
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `group_key` - notification group key
+
+  """
+  @spec notification_group_accounts(Hunter.Client.t(), String.t()) :: [Hunter.Account.t()]
+  def notification_group_accounts(conn, group_key) do
+    HTTPClient.notification_group_accounts(conn, group_key)
+  end
+
+  @doc """
+  Retrieve the number of unread notification groups, capped by the server
+
+  ## Parameters
+
+    * `conn` - connection credentials
+
+  """
+  @spec grouped_unread_count(Hunter.Client.t()) :: non_neg_integer
+  def grouped_unread_count(conn) do
+    HTTPClient.grouped_unread_count(conn)
+  end
 end

--- a/lib/hunter/web_push_subscription.ex
+++ b/lib/hunter/web_push_subscription.ex
@@ -17,6 +17,7 @@ defmodule Hunter.WebPushSubscription do
       `admin.report`)
 
   """
+  alias Hunter.Api.HTTPClient
 
   @type t :: %__MODULE__{
           id: String.t(),
@@ -28,4 +29,65 @@ defmodule Hunter.WebPushSubscription do
 
   @derive [Poison.Encoder]
   defstruct [:id, :endpoint, :standard, :server_key, :alerts]
+
+  @doc """
+  Subscribe to Web Push notifications; each access token can have exactly
+  one subscription, and creating a new one replaces it
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `subscription` - map with `endpoint` (where push alerts will be sent),
+      `keys` (map with the `p256dh` public key and `auth` secret) and
+      optionally `standard` (use standardized web push)
+    * `data` - optional map with `alerts` (map of notification types to
+      booleans) and `policy` (`all`, `followed`, `follower` or `none`)
+
+  """
+  @spec create_push_subscription(Hunter.Client.t(), map, map) :: Hunter.WebPushSubscription.t()
+  def create_push_subscription(conn, subscription, data \\ %{}) do
+    HTTPClient.create_push_subscription(conn, subscription, data)
+  end
+
+  @doc """
+  Retrieve the Web Push subscription tied to the access token
+
+  ## Parameters
+
+    * `conn` - connection credentials
+
+  """
+  @spec push_subscription(Hunter.Client.t()) :: Hunter.WebPushSubscription.t()
+  def push_subscription(conn) do
+    HTTPClient.push_subscription(conn)
+  end
+
+  @doc """
+  Update the `data` portion of the Web Push subscription (which alerts to
+  receive and the delivery policy)
+
+  ## Parameters
+
+    * `conn` - connection credentials
+    * `data` - map with `alerts` (map of notification types to booleans)
+      and/or `policy` (`all`, `followed`, `follower` or `none`)
+
+  """
+  @spec update_push_subscription(Hunter.Client.t(), map) :: Hunter.WebPushSubscription.t()
+  def update_push_subscription(conn, data) do
+    HTTPClient.update_push_subscription(conn, data)
+  end
+
+  @doc """
+  Remove the Web Push subscription tied to the access token
+
+  ## Parameters
+
+    * `conn` - connection credentials
+
+  """
+  @spec delete_push_subscription(Hunter.Client.t()) :: boolean
+  def delete_push_subscription(conn) do
+    HTTPClient.delete_push_subscription(conn)
+  end
 end

--- a/scripts/ci/setup_mastodon.sh
+++ b/scripts/ci/setup_mastodon.sh
@@ -77,12 +77,15 @@ mint_token() {
   $COMPOSE exec -T -e MINT_EMAIL="$1@example.com" web bin/rails runner "
     app = Doorkeeper::Application.find_or_create_by!(name: 'hunter-ci') do |a|
       a.redirect_uri = 'urn:ietf:wg:oauth:2.0:oob'
-      a.scopes = 'read write follow'
+      a.scopes = 'read write follow push'
     end
+    # push scope added later; refresh pre-existing app/token rows in place
+    app.update!(scopes: 'read write follow push') unless app.scopes.to_s.include?('push')
     user = User.find_by!(email: ENV.fetch('MINT_EMAIL'))
     token = Doorkeeper::AccessToken.find_or_create_by!(
       application_id: app.id, resource_owner_id: user.id, revoked_at: nil
     ) { |t| t.scopes = app.scopes.to_s }
+    token.update!(scopes: app.scopes.to_s) if token.scopes.to_s != app.scopes.to_s
     puts token.token
   " | tr -d '[:space:]'
 }

--- a/test/fixtures/grouped_notifications.json
+++ b/test/fixtures/grouped_notifications.json
@@ -1,0 +1,26 @@
+{
+  "accounts": [
+    {
+      "id": "8039",
+      "username": "kadaba",
+      "acct": "kadaba"
+    }
+  ],
+  "statuses": [
+    {
+      "id": "103270115826048975",
+      "content": "<p>hello @milmazz</p>",
+      "visibility": "public"
+    }
+  ],
+  "notification_groups": [
+    {
+      "group_key": "favourite-103270115826048975",
+      "notifications_count": 2,
+      "type": "favourite",
+      "most_recent_notification_id": "196014",
+      "sample_account_ids": ["8039", "23634"],
+      "status_id": "103270115826048975"
+    }
+  ]
+}

--- a/test/hunter/api/transformer_test.exs
+++ b/test/hunter/api/transformer_test.exs
@@ -339,6 +339,17 @@ defmodule Hunter.Api.TransformerTest do
              transform_list("notification_request", :notification_requests)
   end
 
+  test "decodes grouped notification results with nested entities" do
+    results = transform("grouped_notifications", :grouped_notifications)
+
+    assert %Hunter.GroupedNotificationsResults{} = results
+    assert [%Hunter.Account{username: "kadaba"}] = results.accounts
+    assert [%Hunter.Status{visibility: "public"}] = results.statuses
+
+    assert [%Hunter.NotificationGroup{type: "favourite", notifications_count: 2}] =
+             results.notification_groups
+  end
+
   test "decodes a notification group" do
     group = transform("notification_group", :notification_group)
 

--- a/test/hunter/notification_test.exs
+++ b/test/hunter/notification_test.exs
@@ -60,4 +60,166 @@ defmodule Hunter.NotificationTest do
 
     assert_raise Hunter.Error, fn -> Notification.notification(@conn, 0) end
   end
+
+  test "returns the unread count" do
+    stub_request(fn conn ->
+      assert conn.method == "GET"
+      assert conn.request_path == "/api/v1/notifications/unread_count"
+      respond_with(conn, %{count: 7})
+    end)
+
+    assert Notification.unread_count(@conn) == 7
+  end
+
+  test "returns the notification filtering policy" do
+    stub_request(fn conn ->
+      assert conn.method == "GET"
+      assert conn.request_path == "/api/v2/notifications/policy"
+      respond_with_fixture(conn, "notification_policy")
+    end)
+
+    assert %Hunter.NotificationPolicy{for_private_mentions: "filter"} =
+             policy =
+             Notification.notification_policy(@conn)
+
+    assert policy.summary["pending_requests_count"] == 3
+  end
+
+  test "updates the notification filtering policy" do
+    stub_request(fn conn ->
+      assert conn.method == "PATCH"
+      assert conn.request_path == "/api/v2/notifications/policy"
+      assert %{"for_not_following" => "filter"} = read_json_body!(conn)
+      respond_with_fixture(conn, "notification_policy")
+    end)
+
+    assert %Hunter.NotificationPolicy{} =
+             Notification.update_notification_policy(@conn, for_not_following: "filter")
+  end
+
+  test "returns notification requests" do
+    stub_request(fn conn ->
+      assert conn.method == "GET"
+      assert conn.request_path == "/api/v1/notifications/requests"
+      respond_with_fixture(conn, "notification_request", wrap: :list)
+    end)
+
+    assert [%Hunter.NotificationRequest{notifications_count: "5"} = request] =
+             Notification.notification_requests(@conn)
+
+    assert %Hunter.Account{username: "kadaba"} = request.account
+  end
+
+  test "returns a single notification request" do
+    stub_request(fn conn ->
+      assert conn.request_path == "/api/v1/notifications/requests/112456967201894256"
+      respond_with_fixture(conn, "notification_request")
+    end)
+
+    assert %Hunter.NotificationRequest{id: "112456967201894256"} =
+             Notification.notification_request(@conn, "112456967201894256")
+  end
+
+  test "accepts and dismisses a notification request" do
+    stub_request(fn conn ->
+      assert conn.method == "POST"
+      assert conn.request_path == "/api/v1/notifications/requests/112456967201894256/accept"
+      respond_with(conn, %{})
+    end)
+
+    assert Notification.accept_notification_request(@conn, "112456967201894256") == true
+
+    stub_request(fn conn ->
+      assert conn.method == "POST"
+      assert conn.request_path == "/api/v1/notifications/requests/112456967201894256/dismiss"
+      respond_with(conn, %{})
+    end)
+
+    assert Notification.dismiss_notification_request(@conn, "112456967201894256") == true
+  end
+
+  test "accepts and dismisses notification requests in bulk" do
+    stub_request(fn conn ->
+      assert conn.method == "POST"
+      assert conn.request_path == "/api/v1/notifications/requests/accept"
+      assert %{"id" => ["1", "2"]} = read_json_body!(conn)
+      respond_with(conn, %{})
+    end)
+
+    assert Notification.accept_notification_requests(@conn, ["1", "2"]) == true
+
+    stub_request(fn conn ->
+      assert conn.method == "POST"
+      assert conn.request_path == "/api/v1/notifications/requests/dismiss"
+      assert %{"id" => ["3"]} = read_json_body!(conn)
+      respond_with(conn, %{})
+    end)
+
+    assert Notification.dismiss_notification_requests(@conn, ["3"]) == true
+  end
+
+  test "checks whether accepted notification requests have been merged" do
+    stub_request(fn conn ->
+      assert conn.request_path == "/api/v1/notifications/requests/merged"
+      respond_with(conn, %{merged: true})
+    end)
+
+    assert Notification.notification_requests_merged?(@conn) == true
+  end
+
+  test "returns grouped notifications" do
+    stub_request(fn conn ->
+      assert conn.method == "GET"
+      assert conn.request_path == "/api/v2/notifications"
+      assert conn.query_string == "limit=10"
+      respond_with_fixture(conn, "grouped_notifications")
+    end)
+
+    results = Notification.grouped_notifications(@conn, limit: 10)
+
+    assert %Hunter.GroupedNotificationsResults{} = results
+    assert [%Hunter.NotificationGroup{type: "favourite"}] = results.notification_groups
+  end
+
+  test "returns a single notification group" do
+    stub_request(fn conn ->
+      assert conn.request_path == "/api/v2/notifications/favourite-103270115826048975"
+      respond_with_fixture(conn, "grouped_notifications")
+    end)
+
+    assert %Hunter.GroupedNotificationsResults{} =
+             Notification.notification_group(@conn, "favourite-103270115826048975")
+  end
+
+  test "dismisses a notification group" do
+    stub_request(fn conn ->
+      assert conn.method == "POST"
+      assert conn.request_path == "/api/v2/notifications/favourite-103270115826048975/dismiss"
+      respond_with(conn, %{})
+    end)
+
+    assert Notification.dismiss_notification_group(@conn, "favourite-103270115826048975") ==
+             true
+  end
+
+  test "returns accounts of a notification group" do
+    stub_request(fn conn ->
+      assert conn.request_path ==
+               "/api/v2/notifications/favourite-103270115826048975/accounts"
+
+      respond_with_fixture(conn, "account", wrap: :list)
+    end)
+
+    assert [%Hunter.Account{username: "milmazz"}] =
+             Notification.notification_group_accounts(@conn, "favourite-103270115826048975")
+  end
+
+  test "returns the grouped unread count" do
+    stub_request(fn conn ->
+      assert conn.request_path == "/api/v2/notifications/unread_count"
+      respond_with(conn, %{count: 3})
+    end)
+
+    assert Notification.grouped_unread_count(@conn) == 3
+  end
 end

--- a/test/hunter/web_push_subscription_test.exs
+++ b/test/hunter/web_push_subscription_test.exs
@@ -1,0 +1,79 @@
+defmodule Hunter.WebPushSubscriptionTest do
+  use Hunter.ReqCase, async: true
+
+  alias Hunter.WebPushSubscription
+
+  @conn Hunter.Client.new(base_url: "https://mastodon.example", access_token: "123456")
+
+  @subscription %{
+    endpoint: "https://yourdomain.example/listener",
+    keys: %{
+      p256dh:
+        "BCk-QqERU0q-CfYZjcuB6lnyyOYfJ2AifKqfeGIm7Z-HiTU5T9eTG5GxVA0_OH5mMlI4UkkDTpaZwozy0TzdZ2M=",
+      auth: "tBHItJI5svbpez7KI4CCXg=="
+    },
+    standard: true
+  }
+
+  test "creates a push subscription" do
+    stub_request(fn conn ->
+      assert conn.method == "POST"
+      assert conn.request_path == "/api/v1/push/subscription"
+
+      body = read_json_body!(conn)
+      assert body["subscription"]["endpoint"] == "https://yourdomain.example/listener"
+      assert body["subscription"]["keys"]["auth"] == "tBHItJI5svbpez7KI4CCXg=="
+      assert body["data"]["alerts"]["mention"] == true
+
+      respond_with_fixture(conn, "web_push_subscription")
+    end)
+
+    assert %WebPushSubscription{id: "328183", standard: true} =
+             WebPushSubscription.create_push_subscription(@conn, @subscription, %{
+               alerts: %{mention: true}
+             })
+  end
+
+  test "returns the current push subscription" do
+    stub_request(fn conn ->
+      assert conn.method == "GET"
+      assert conn.request_path == "/api/v1/push/subscription"
+      respond_with_fixture(conn, "web_push_subscription")
+    end)
+
+    subscription = WebPushSubscription.push_subscription(@conn)
+
+    assert %WebPushSubscription{endpoint: "https://yourdomain.example/listener"} = subscription
+    assert subscription.alerts["mention"] == true
+  end
+
+  test "updates the push subscription alerts" do
+    stub_request(fn conn ->
+      assert conn.method == "PUT"
+      assert conn.request_path == "/api/v1/push/subscription"
+      assert %{"data" => %{"alerts" => %{"reblog" => true}}} = read_json_body!(conn)
+      respond_with_fixture(conn, "web_push_subscription")
+    end)
+
+    assert %WebPushSubscription{} =
+             WebPushSubscription.update_push_subscription(@conn, %{alerts: %{reblog: true}})
+  end
+
+  test "deletes the push subscription" do
+    stub_request(fn conn ->
+      assert conn.method == "DELETE"
+      assert conn.request_path == "/api/v1/push/subscription"
+      respond_with(conn, %{})
+    end)
+
+    assert WebPushSubscription.delete_push_subscription(@conn) == true
+  end
+
+  test "API errors raise Hunter.Error" do
+    stub_request(fn conn ->
+      respond_with(conn, %{error: "Not found"}, 404)
+    end)
+
+    assert_raise Hunter.Error, fn -> WebPushSubscription.push_subscription(@conn) end
+  end
+end

--- a/test/integration/mastodon_test.exs
+++ b/test/integration/mastodon_test.exs
@@ -275,6 +275,122 @@ defmodule Hunter.Integration.MastodonTest do
     Relationship.unfollow(conn, id2)
   end
 
+  test "notification policy roundtrip and unread counts", %{conn: conn} do
+    policy = Notification.notification_policy(conn)
+    assert %Hunter.NotificationPolicy{} = policy
+    original = policy.for_not_following
+
+    assert %Hunter.NotificationPolicy{for_not_following: "filter"} =
+             Notification.update_notification_policy(conn, for_not_following: "filter")
+
+    on_exit(fn ->
+      Notification.update_notification_policy(conn, for_not_following: original)
+    end)
+
+    assert %Hunter.NotificationPolicy{for_not_following: ^original} =
+             Notification.update_notification_policy(conn, for_not_following: original)
+
+    assert is_integer(Notification.unread_count(conn))
+    assert is_integer(Notification.grouped_unread_count(conn))
+  end
+
+  test "filtered notifications become requests that can be accepted", %{
+    conn: conn,
+    conn2: conn2
+  } do
+    # filter notifications from accounts the user does not follow, then have
+    # the (unfollowed) second account mention them
+    original = Notification.notification_policy(conn).for_not_following
+
+    Notification.update_notification_policy(conn, for_not_following: "filter")
+    on_exit(fn -> Notification.update_notification_policy(conn, for_not_following: original) end)
+
+    %Status{id: status_id} = Status.create_status(conn2, "filtered mention @hunter #hunterci")
+    on_exit(fn -> destroy_quietly(conn2, status_id) end)
+
+    request =
+      eventually(fn ->
+        case Enum.find(Notification.notification_requests(conn), fn request ->
+               request.account.username == "kadaba"
+             end) do
+          nil -> raise "notification request not created yet"
+          request -> request
+        end
+      end)
+
+    assert %Hunter.NotificationRequest{} = request
+
+    assert %Hunter.NotificationRequest{id: _} =
+             Notification.notification_request(conn, request.id)
+
+    assert Notification.accept_notification_request(conn, request.id)
+    eventually(fn -> assert Notification.notification_requests_merged?(conn) end)
+
+    Notification.update_notification_policy(conn, for_not_following: original)
+    Status.destroy_status(conn2, status_id)
+  end
+
+  test "grouped notifications reference accounts and statuses", %{conn: conn, conn2: conn2} do
+    %Status{id: status_id} = Status.create_status(conn2, "grouped mention @hunter #hunterci")
+    on_exit(fn -> destroy_quietly(conn2, status_id) end)
+
+    group =
+      eventually(fn ->
+        results = Notification.grouped_notifications(conn, types: ["mention"])
+        assert %Hunter.GroupedNotificationsResults{} = results
+
+        case Enum.find(results.notification_groups, fn group ->
+               group.type == "mention" and group.status_id == status_id
+             end) do
+          nil -> raise "notification group not delivered yet"
+          group -> group
+        end
+      end)
+
+    assert %Hunter.GroupedNotificationsResults{notification_groups: [_ | _]} =
+             Notification.notification_group(conn, group.group_key)
+
+    accounts = Notification.notification_group_accounts(conn, group.group_key)
+    assert Enum.any?(accounts, &(&1.username == "kadaba"))
+
+    assert Notification.dismiss_notification_group(conn, group.group_key)
+
+    Status.destroy_status(conn2, status_id)
+  end
+
+  test "web push subscription lifecycle", %{conn: conn} do
+    subscription = %{
+      endpoint: "https://push.example.com/listener",
+      keys: %{
+        p256dh:
+          "BCk-QqERU0q-CfYZjcuB6lnyyOYfJ2AifKqfeGIm7Z-HiTU5T9eTG5GxVA0_OH5mMlI4UkkDTpaZwozy0TzdZ2M=",
+        auth: "tBHItJI5svbpez7KI4CCXg=="
+      }
+    }
+
+    created =
+      Hunter.WebPushSubscription.create_push_subscription(conn, subscription, %{
+        alerts: %{mention: true}
+      })
+
+    assert %Hunter.WebPushSubscription{endpoint: "https://push.example.com/listener"} = created
+    on_exit(fn -> delete_push_quietly(conn) end)
+
+    fetched = Hunter.WebPushSubscription.push_subscription(conn)
+    assert fetched.id == created.id
+    assert fetched.alerts["mention"] == true
+
+    updated =
+      Hunter.WebPushSubscription.update_push_subscription(conn, %{
+        alerts: %{mention: true, reblog: true}
+      })
+
+    assert updated.alerts["reblog"] == true
+
+    assert Hunter.WebPushSubscription.delete_push_subscription(conn)
+    assert_raise Hunter.Error, fn -> Hunter.WebPushSubscription.push_subscription(conn) end
+  end
+
   test "query parameters take effect server-side", %{conn: conn} do
     %Account{id: account_id} = Account.verify_credentials(conn)
 
@@ -376,6 +492,13 @@ defmodule Hunter.Integration.MastodonTest do
 
   defp unfollow_quietly(conn, id) do
     Relationship.unfollow(conn, id)
+    :ok
+  rescue
+    Hunter.Error -> :ok
+  end
+
+  defp delete_push_quietly(conn) do
+    Hunter.WebPushSubscription.delete_push_subscription(conn)
     :ok
   rescue
     Hunter.Error -> :ok

--- a/test/integration/mastodon_test.exs
+++ b/test/integration/mastodon_test.exs
@@ -331,16 +331,20 @@ defmodule Hunter.Integration.MastodonTest do
   end
 
   test "grouped notifications reference accounts and statuses", %{conn: conn, conn2: conn2} do
-    %Status{id: status_id} = Status.create_status(conn2, "grouped mention @hunter #hunterci")
-    on_exit(fn -> destroy_quietly(conn2, status_id) end)
+    # favourites are groupable (mentions are not: their synthesized
+    # ungrouped-* keys match nothing on the group endpoints)
+    %Status{id: status_id} = Status.create_status(conn, "groupable probe #hunterci")
+    on_exit(fn -> destroy_quietly(conn, status_id) end)
+
+    assert %Status{} = Status.favourite(conn2, status_id)
 
     group =
       eventually(fn ->
-        results = Notification.grouped_notifications(conn, types: ["mention"])
+        results = Notification.grouped_notifications(conn, types: ["favourite"])
         assert %Hunter.GroupedNotificationsResults{} = results
 
         case Enum.find(results.notification_groups, fn group ->
-               group.type == "mention" and group.status_id == status_id
+               group.type == "favourite" and group.status_id == status_id
              end) do
           nil -> raise "notification group not delivered yet"
           group -> group
@@ -355,7 +359,7 @@ defmodule Hunter.Integration.MastodonTest do
 
     assert Notification.dismiss_notification_group(conn, group.group_key)
 
-    Status.destroy_status(conn2, status_id)
+    Status.destroy_status(conn, status_id)
   end
 
   test "web push subscription lifecycle", %{conn: conn} do


### PR DESCRIPTION
Closes #122

All 15 endpoints from the checklist, on the post-#134 three-layer pattern (HTTPClient → module function → facade delegate), test-first.

## Counts & policy (4.3)
- `unread_count/1` and `grouped_unread_count/1` — return the integer count
- `notification_policy/1`, `update_notification_policy/2` — `GET/PATCH /api/v2/notifications/policy`

## Notification requests (4.3)
- `notification_requests/2`, `notification_request/2`
- `accept_notification_request/2`, `dismiss_notification_request/2`, bulk `accept_notification_requests/2` / `dismiss_notification_requests/2`
- `notification_requests_merged?/1`

## Grouped notifications (4.3)
- New `Hunter.GroupedNotificationsResults` entity (the deduplicated accounts/statuses/groups wrapper deferred from #119)
- `grouped_notifications/2`, `notification_group/2`, `dismiss_notification_group/2`, `notification_group_accounts/2`

## Web Push (2.4)
- `create_push_subscription/3`, `push_subscription/1`, `update_push_subscription/2`, `delete_push_subscription/1` on `Hunter.WebPushSubscription`

## Testing
- 19 new Req.Test unit tests asserting methods, paths, query strings, and JSON bodies (nested `subscription`/`data` payloads included)
- 4 new integration tests: policy roundtrip + unread counts; a real filtered-notification flow (set policy to filter, unfollowed account mentions, request appears, accept, merged); grouped notifications referencing accounts/statuses with group fetch/dismiss; full push subscription lifecycle (CI's Mastodon has VAPID keys configured)
- 187 tests + 2 doctests, 0 failures; dialyzer, credo --strict, formatter pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)