### PR TITLE
Make filtered-notification integration test idempotent (#144)

### DIFF
--- a/test/integration/mastodon_test.exs
+++ b/test/integration/mastodon_test.exs
@@ -298,6 +298,13 @@ defmodule Hunter.Integration.MastodonTest do
     conn: conn,
     conn2: conn2
   } do
+    # accepting a request grants the sender a permanent NotificationPermission,
+    # so a previous run against a reused database would leave kadaba's mentions
+    # unfiltered; block/unblock is the only API-visible way to revoke it
+    %Account{id: id2} = Hunter.verify_credentials(conn2)
+    reset_notification_permission(conn, id2)
+    on_exit(fn -> reset_notification_permission(conn, id2) end)
+
     # filter notifications from accounts the user does not follow, then have
     # the (unfollowed) second account mention them
     original = Hunter.notification_policy(conn).for_not_following
@@ -575,6 +582,22 @@ defmodule Hunter.Integration.MastodonTest do
 
   defp unlock_quietly(conn) do
     Hunter.update_credentials(conn, %{locked: false})
+    :ok
+  rescue
+    Hunter.Error -> :ok
+  end
+
+  # Mastodon's BlockService destroys any NotificationPermission granted to the
+  # blocked account, so a block/unblock pair resets notification filtering for
+  # that sender. The unblock runs even if the block fails.
+  defp reset_notification_permission(conn, id) do
+    try do
+      Hunter.block(conn, id)
+    rescue
+      Hunter.Error -> :ok
+    end
+
+    Hunter.unblock(conn, id)
     :ok
   rescue
     Hunter.Error -> :ok


### PR DESCRIPTION
## Summary

Fixes the second failure in #144 (`filtered notifications become requests that can be accepted`) and documents why the first one can't be fixed here.

- Accepting a notification request grants the sender a **permanent `NotificationPermission`**, so any re-run against a reused database found kadaba's mentions no longer filtered (`FilterCondition#override_for_sender?`) and timed out waiting for a `NotificationRequest`.
- Mastodon has no API to revoke the permission directly, but `BlockService` destroys it (present in both v4.4.8 and v4.6.1), so the test now resets it with a block/unblock pair at the start and in `on_exit`, making it self-healing on reused databases.

## Investigation findings for the rest of #144

- On a **truly fresh** database the test passes against Mastodon 4.6.1 too — the failure reported in #144 was leftover state, not a 4.6 behavior change.
- The remaining failure (second `POST /api/v1/statuses` with the same `Idempotency-Key` → 500) is an **upstream Mastodon 4.6 regression**, still present on `main`: the `with_idempotency` refactor in `PostStatusService` returns the duplicate from the helper's own scope, `call` continues with `@status = nil`, and `postprocess_status!` crashes in `ProcessHashtagsService` (`NoMethodError: undefined method 'account' for nil`). Reproducible with plain curl. Nothing in Hunter can fix it; it blocks bumping CI toward 4.6 unless that assertion is version-guarded.

## Test plan

- [x] Reproduced the failure on a reused 4.6.1 database (leftover permission), then verified the fixed test passes 3 consecutive runs there
- [x] Fresh 4.4.8 stack (CI-pinned images): full integration suite 29 tests, 0 failures

Refs #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)