### PR TITLE
Docs/spec polish follow-ups from the facade flatten

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,14 @@
       filters (`filter_statuses/2`, `add_status_to_filter/3`,
       `filter_status/2`, `destroy_filter_status/2`)
 
+  * Fixes
+    - Docs/spec polish from the facade flatten ([#139]): restored the
+      `search/3` URL-query and `vote/3` multiple-choice doc notes and the
+      clarifying summary lines on `accept_notification_request/2` and the
+      notification-request dismiss functions; `blocked_domains/2` is now
+      typed `[String.t()]`, continuing the typespec-honesty work from
+      [#116]; removed a dead raw-binary body clause in the request layer
+
 ## v0.7.0
 
   * Breaking changes
@@ -182,6 +190,7 @@
 [#116]: https://github.com/milmazz/hunter/issues/116
 [#122]: https://github.com/milmazz/hunter/issues/122
 [#3]: https://github.com/milmazz/hunter/issues/3
+[#139]: https://github.com/milmazz/hunter/issues/139
 [#123]: https://github.com/milmazz/hunter/issues/123
 [#124]: https://github.com/milmazz/hunter/issues/124
 [#126]: https://github.com/milmazz/hunter/issues/126

--- a/lib/hunter.ex
+++ b/lib/hunter.ex
@@ -732,7 +732,9 @@ defmodule Hunter do
   ## Parameters
 
     * `conn` - connection credentials
-    * `q` - the search query
+    * `q` - the search query, if `q` is a URL Mastodon will attempt to fetch
+      the provided account or status, otherwise it will do a local account
+      and hashtag search
     * `options` - option list
 
   ## Options
@@ -813,7 +815,8 @@ defmodule Hunter do
 
     * `conn` - connection credentials
     * `id` - poll identifier
-    * `choices` - list of option indices to vote for (zero-based)
+    * `choices` - list of option indices to vote for (zero-based); multiple
+      choices are only allowed on multiple-choice polls
 
   """
   @spec vote(Hunter.Client.t(), String.t() | non_neg_integer, [non_neg_integer]) ::
@@ -1642,7 +1645,8 @@ defmodule Hunter do
   end
 
   @doc """
-  Accept a notification request
+  Accept a notification request, so future notifications from the account
+  are delivered normally
 
   ## Parameters
 
@@ -1656,7 +1660,7 @@ defmodule Hunter do
   end
 
   @doc """
-  Dismiss a notification request
+  Dismiss a notification request, removing it and its filtered notifications
 
   ## Parameters
 
@@ -1685,7 +1689,8 @@ defmodule Hunter do
   end
 
   @doc """
-  Dismiss multiple notification requests
+  Dismiss multiple notification requests, removing them and their filtered
+  notifications
 
   ## Parameters
 
@@ -2181,7 +2186,7 @@ defmodule Hunter do
     * `limit` - maximum number of blocks to get, default: 40, max: 80
 
   """
-  @spec blocked_domains(Hunter.Client.t(), Keyword.t()) :: list
+  @spec blocked_domains(Hunter.Client.t(), Keyword.t()) :: [String.t()]
   def blocked_domains(conn, options \\ []) do
     Request.request!(conn, :get, "/api/v1/domain_blocks", nil, options)
   end

--- a/lib/hunter/api/request.ex
+++ b/lib/hunter/api/request.ex
@@ -89,7 +89,6 @@ defmodule Hunter.Api.Request do
   defp split_payload(_method, data), do: {[body: process_request_body(data)], []}
 
   defp process_request_body([]), do: "{}"
-  defp process_request_body(data) when is_binary(data), do: data
   defp process_request_body(data), do: Poison.encode!(data)
 
   defp process_request_header(headers) do


### PR DESCRIPTION
Fixes #139 — all four polish items that fell out during the 0.7.0 facade flatten (#137, #138). No behavior changes.

- **`search/3` / `vote/3` doc notes restored**: the pre-flatten `Hunter.Result.search` clause ("if `q` is a URL Mastodon will attempt to fetch the provided account or status, otherwise it will do a local account and hashtag search") and the `Hunter.Poll.vote` clause ("multiple choices are only allowed on multiple-choice polls") are back on the facade docs, recovered from `e4c0f14~1`.
- **Notification-request summary lines restored**: `accept_notification_request/2` ("…so future notifications from the account are delivered normally") and `dismiss_notification_request/2` ("…removing it and its filtered notifications") get their pre-flatten wording back verbatim; `dismiss_notification_requests/2` never had a clarifying clause in the entity module, so it gets the parallel plural one ("…removing them and their filtered notifications").
- **`@spec blocked_domains/2`** tightened from `:: list` to `:: [String.t()]` (the endpoint returns bare domain strings), continuing #135/#116.
- **Dead clause removed**: `process_request_body(data) when is_binary(data)` in `lib/hunter/api/request.ex` — audited all write-verb `Request.request!` call sites; every payload is a map, keyword list, or `{:form_multipart, parts}`, so the raw-binary clause is unreachable since the flatten.

## Verification

`mix test` (2 doctests, 245 tests, 0 failures), `mix credo --strict`, `mix dialyzer`, `mix docs`, and `mix format --check-formatted` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)